### PR TITLE
Add the colors parameter and radius scale 

### DIFF
--- a/docs/source/api/plotting/geodesics_scatter.rst
+++ b/docs/source/api/plotting/geodesics_scatter.rst
@@ -1,0 +1,31 @@
+Static 2D Plotting module
+=========================
+
+This module contains the basic classes for static plottings in
+2-dimensions for scatter and line:
+
+.. automodule:: einsteinpy.plotting.geodesics_scatter
+    :members:
+
+Color
+=====
+* Attractor : 
+    User can give the color to attractor of his/her choice.
+    It can be passed while making the object of geodesics_static class.
+    Default color of attractor is "black".
+
+    .. code-block:: python
+        
+        self.attractor_color = attractor_color
+        plt.scatter(0, 0, color=self.attractor_color)
+
+* Geodesic : 
+    User can give the color to the orbit of the particle moving around the attractor of his/her choice.
+    It can be passed while making the object of geodesics_scatter class.
+    Default color is "Oranges".
+    
+    .. code-block:: python
+        
+        self.cmap_color = cmap_color
+        plt.scatter(pos_x, pos_y, s=1, c=time, cmap=self.cmap_color)
+        

--- a/docs/source/api/plotting/geodesics_static.rst
+++ b/docs/source/api/plotting/geodesics_static.rst
@@ -6,3 +6,60 @@ This module contains the basic classes for static plottings in
 
 .. automodule:: einsteinpy.plotting.geodesics_static
     :members:
+
+Auto and Manual scaling
+=======================
+EinsteinPy supports Automatic and Manual scaling of the attractor to make plots look better since radius of 
+attractor can be really small and not visible.
+
+* Manual_Scaling : 
+    If the user provides the attractor_radius_scale, then the autoscaling will not work.
+    This is checked by initialising the  attractor_radius_scale by -1 and if the user enters the value then 
+    it will be >0 so the value won't remain -1 which is easily checked.
+    
+    The radius is multiplied to the value given in attractor_radius_scale
+    
+    .. code-block:: python
+
+        radius = radius * self.attractor_radius_scale
+
+* Auto Scaling : 
+    If the user does not provide the attractor_radius_scale, the value will be initialised to -1 and 
+    then we will call the auto scaling function. In autoscaling, the attractor radius is first 
+    initialised to the minimum distance between the attractor and the object moving around it. 
+    Now, if this radius is greater than the 1/12th of minimum of range of X and Y coordinates then,
+    the radius is initialised to this minimum. This is done so that the plots are easy to look at.
+
+    minrad_nooverlap : Stores the minimum distance between the particle and attractor
+    .. code-block:: python
+
+        for i in range(0, len(self.xarr)):
+            minrad_nooverlap = min( minrad_nooverlap, self.mindist(self.xarr[i], self.yarr[i]))
+
+    minlen_plot : Stores the minimum of range of X and Y axis
+    
+    .. code-block:: python
+            
+            xlen = max(self.xarr) - min(self.xarr)
+            ylen = max(self.yarr) - min(self.yarr)
+            minlen_plot = min(xlen, ylen)
+    
+    multiplier : Stores the value which is multiplied to the radius to make it 1/12th of the minlenplot
+    
+    .. code-block:: python
+            
+            mulitplier = minlen_plot / (12 * radius)
+            min_radius = radius * mulitplier
+
+
+Attractor Color
+===============
+* Color Options : 
+    User can give the color to attractor of his/her choice.
+    It can be passed while calling the geodesics_static class.
+    Default color of attractor is "black".
+
+    .. code-block:: python
+        
+        self.attractor_color = attractor_color
+        mpl.patches.Circle( (0, 0), radius.value, lw=0, color=self.attractor_color)

--- a/docs/source/api/plotting/plotting_index.rst
+++ b/docs/source/api/plotting/plotting_index.rst
@@ -8,3 +8,4 @@ This module contains the basic classes for static and interactive
     :maxdepth: 2
 
     geodesics_static
+    geodesics_scatter

--- a/src/einsteinpy/plotting/geodesics_scatter.py
+++ b/src/einsteinpy/plotting/geodesics_scatter.py
@@ -11,14 +11,28 @@ class ScatterGeodesicPlotter:
     Class for plotting static matplotlib plots.
     """
 
-    def __init__(self, mass, time=0 * u.s):
+    def __init__(
+        self, mass, time=0 * u.s, attractor_color="black", cmap_color="Oranges"
+    ):
+        """
+
+        Parameters
+        ----------
+        attractor_color : string, optional
+            Color which is used to denote the attractor. Defaults to black.
+        cmap_color : string, optional
+            Color used in function plot.
+
+        """
         self.mass = mass
         self.time = time
         self._attractor_present = False
+        self.attractor_color = attractor_color
+        self.cmap_color = cmap_color
 
     def _plot_attractor(self):
         self._attractor_present = True
-        plt.scatter(0, 0, color="black")
+        plt.scatter(0, 0, color=self.attractor_color)
 
     def plot(self, pos_vec, vel_vec, end_lambda=10, step_size=1e-3):
         """
@@ -51,7 +65,7 @@ class ScatterGeodesicPlotter:
         pos_x = r * np.cos(phi)
         pos_y = r * np.sin(phi)
 
-        plt.scatter(pos_x, pos_y, s=1, c=time, cmap="Oranges")
+        plt.scatter(pos_x, pos_y, s=1, c=time, cmap=self.cmap_color)
 
         if not self._attractor_present:
             self._plot_attractor()

--- a/src/einsteinpy/plotting/geodesics_static.py
+++ b/src/einsteinpy/plotting/geodesics_static.py
@@ -1,4 +1,5 @@
 import random
+import sys
 
 import astropy.units as u
 import matplotlib as mpl
@@ -11,18 +12,56 @@ from einsteinpy.utils import schwarzschild_radius
 
 class StaticGeodesicPlotter:
     """
-    Class for plotting static matplotlib plots
+    Class for plotting static matplotlib plots.
     """
 
-    def __init__(self, mass, time=0 * u.s, ax=None):
+    def __init__(
+        self,
+        mass,
+        time=0 * u.s,
+        ax=None,
+        attractor_radius_scale=-1.0,
+        attractor_color="#ffcc00",
+    ):
+        """
+
+        Parameters
+        ----------
+        attractor_radius_scale : float, optional
+            Scales the attractor radius by the value given. Default is 1. It is used to make plots look more clear if needed.
+        attractor_color : string, optional
+            Color which is used to denote the attractor. Defaults to #ffcc00.
+
+        """
         self.ax = ax
         if not self.ax:
             _, self.ax = plt.subplots(figsize=(6, 6))
         self.time = time
         self.mass = mass
         self._attractor_present = False
+        self.attractor_color = attractor_color
+        self.attractor_radius_scale = attractor_radius_scale
+        self.__xarr = np.array([])
+        self.__yarr = np.array([])
+        self.get_curr_plot_radius = 0
 
     def plot_trajectory(self, pos_vec, vel_vec, end_lambda, step_size, color):
+        """
+
+        Parameters
+        ----------
+        pos_vec : list
+            list of r, theta & phi components along with ~astropy.units.
+        vel_vec : list
+            list of velocities of r, theta & phi components along with ~astropy.units.
+        end_lambda : float, optional
+            Lambda where iteartions will stop.
+        step_size : float, optional
+            Step size for the ODE.
+        color : string
+            Color of the Geodesic
+
+        """
         swc = Schwarzschild.from_spherical(pos_vec, vel_vec, self.time, self.mass)
 
         vals = swc.calculate_trajectory(
@@ -45,10 +84,69 @@ class StaticGeodesicPlotter:
         if not self._attractor_present:
             self._draw_attractor()
 
-    def _draw_attractor(self, min_radius=10 * u.km):
-        radius = max((schwarzschild_radius(self.mass) * 10000), min_radius.to(u.km))
-        color = "#ffcc00"
-        self.ax.add_patch(mpl.patches.Circle((0, 0), radius.value, lw=0, color=color))
+    def __get_x_y(self, pos_vec, vel_vec, end_lambda, step_size):
+        """
+
+        Parameters
+        ----------
+        pos_vec : list
+            list of r, theta & phi components along with ~astropy.units.
+        vel_vec : list
+            list of velocities of r, theta & phi components along with ~astropy.units.
+        end_lambda : float, optional
+            Lambda where iteartions will stop.
+        step_size : float, optional
+            Step size for the ODE.
+
+        """
+        swc = Schwarzschild.from_spherical(pos_vec, vel_vec, self.time, self.mass)
+
+        vals = swc.calculate_trajectory(
+            end_lambda=end_lambda, OdeMethodKwargs={"stepsize": step_size}
+        )[1]
+
+        time = np.array([coord[0] for coord in vals])
+        r = np.array([coord[1] for coord in vals])
+        theta = np.array([coord[2] for coord in vals])
+        phi = np.array([coord[3] for coord in vals])
+
+        x = r * np.cos(phi)
+        y = r * np.sin(phi)
+        self.__xarr = x
+        self.__yarr = y
+        return x, y
+
+    def mindist(self, x, y):
+        return np.sqrt(x * x + y * y)
+
+    def _draw_attractor(self):
+        radius = schwarzschild_radius(self.mass)
+        if self.attractor_radius_scale == -1.0:
+            minrad_nooverlap = self.mindist(self.__xarr[0], self.__yarr[0])
+            for i in range(0, len(self.__xarr)):
+                minrad_nooverlap = min(
+                    minrad_nooverlap, self.mindist(self.__xarr[i], self.__yarr[i])
+                )
+
+            xlen = max(self.__xarr) - min(self.__xarr)
+            ylen = max(self.__yarr) - min(self.__yarr)
+            minlen_plot = min(xlen, ylen)
+            mulitplier = minlen_plot / (12 * radius)
+            min_radius = radius * mulitplier
+
+            radius = min(min_radius, minrad_nooverlap)
+            self.get_curr_plot_radius = radius
+            self.ax.add_patch(
+                mpl.patches.Circle((0, 0), radius, lw=0, color=self.attractor_color)
+            )
+        else:
+            radius = radius * self.attractor_radius_scale
+            self.get_curr_plot_radius = radius
+            self.ax.add_patch(
+                mpl.patches.Circle(
+                    (0, 0), radius.value, lw=0, color=self.attractor_color
+                )
+            )
 
     def plot(
         self,
@@ -58,7 +156,25 @@ class StaticGeodesicPlotter:
         step_size=1e-3,
         color="#{:06x}".format(random.randint(0, 0xFFFFFF)),
     ):
+        """
 
+        Parameters
+        ----------
+        pos_vec : list
+            list of r, theta & phi components along with ~astropy.units.
+        vel_vec : list
+            list of velocities of r, theta & phi components along with ~astropy.units.
+        end_lambda : float, optional
+            Lambda where iteartions will stop.
+        step_size : float, optional
+            Step size for the ODE.
+        color : string
+            Color of the Geodesic
+
+        """
+        self.__xarr, self.__yarr = self.__get_x_y(
+            pos_vec, vel_vec, end_lambda, step_size
+        )
         self.plot_attractor()
         self._attractor_present = True
 
@@ -77,3 +193,6 @@ class StaticGeodesicPlotter:
 
     def save(self, name="static_geodesic.png"):
         plt.savefig(name)
+
+    def show(self):
+        plt.show()

--- a/src/einsteinpy/tests/test_plotting/test_staticgeodesicplotter.py
+++ b/src/einsteinpy/tests/test_plotting/test_staticgeodesicplotter.py
@@ -29,8 +29,8 @@ def test_staticgeodesicplotter_has_axes(dummy_data):
     assert cl._attractor_present is False
 
 
-@mock.patch("einsteinpy.plotting.geodesics_static.StaticGeodesicPlotter.plot_attractor")
-def test_plot_calls_plot_attractor(mock_plot_attractor):
+@mock.patch("einsteinpy.plotting.geodesics_static.plt.show")
+def test_plot_calls_plt_show(mock_show):
     r = [306 * u.m, np.pi / 2 * u.rad, np.pi / 2 * u.rad]
     v = [0 * u.m / u.s, 0 * u.rad / u.s, 951.0 * u.rad / u.s]
     m = 4e24 * u.kg
@@ -38,7 +38,8 @@ def test_plot_calls_plot_attractor(mock_plot_attractor):
     ss = 0.5e-6
     cl = StaticGeodesicPlotter(m)
     cl.plot(r, v, el, ss)
-    mock_plot_attractor.assert_called_with()
+    cl.show()
+    mock_show.assert_called_with()
     assert cl._attractor_present
 
 
@@ -54,3 +55,20 @@ def test_plot_save_saves_plot(mock_save):
     name = "test_plot.png"
     cl.save(name)
     mock_save.assert_called_with(name)
+
+
+def test_plot_calls_draw_attractor_Manualscale(dummy_data):
+    r, v, _, m, _, el, ss = dummy_data
+    cl = StaticGeodesicPlotter(m, attractor_radius_scale=1500)
+    cl.plot(r, v, el, ss)
+    assert cl._attractor_present
+    assert cl.attractor_radius_scale == 1500
+    assert cl.get_curr_plot_radius != -1
+
+
+def test_plot_calls_draw_attractor_AutoScale(dummy_data):
+    r, v, _, m, _, el, ss = dummy_data
+    cl = StaticGeodesicPlotter(m)
+    cl.plot(r, v, el, ss)
+    assert cl._attractor_present
+    assert cl.get_curr_plot_radius != -1


### PR DESCRIPTION

<!-- Please fill below the issue number which this code fixes -->
Fixes #156  Fixes #150 

I have added the radius scaling factor (defaults to 1) which will scale the attractor radius, the picture below shows the results.
![Screenshot from 2019-04-07 17-16-53](https://user-images.githubusercontent.com/34454817/55683345-41f5c580-595c-11e9-9e60-d4ee0b2d3c57.png)

I have added the color parameters in ScatterGeodesicPlotter classes which defaluts to :
attractor_color= "black" and cmap_color="Oranges" in ScatterGeodesicPlotter class
This is how it looks:
![Screenshot from 2019-04-07 17-12-16](https://user-images.githubusercontent.com/34454817/55683348-46ba7980-595c-11e9-95fb-e2432779bfbf.png)

Color Attribute in StaticGeodesicPlotter:
![Screenshot from 2019-04-07 19-05-22](https://user-images.githubusercontent.com/34454817/55684477-753e5180-5968-11e9-9bc9-1812c8f1e0b7.png)
