### PR TITLE
Removes all the unnecessary pytest.mark.parametrize 

### DIFF
--- a/src/einsteinpy/tests/test_metric/test_kerrnewman.py
+++ b/src/einsteinpy/tests/test_metric/test_kerrnewman.py
@@ -52,11 +52,12 @@ def test_calculate_trajectory0():
     assert_allclose(v_apehelion, 29.29, rtol=0.01)
 
 
-@pytest.mark.parametrize(
-    "M, r, end_lambda, stepsize", [(0.5 * 5.972e24 * u.kg, 1000.0 * u.km, 1000.0, 0.5)]
-)
-def test_calculate_trajectory1(M, r, end_lambda, stepsize):
+def test_calculate_trajectory1():
     # the test particle should not move as gravitational & electromagnetic forces are balanced
+    M = 0.5 * 5.972e24 * u.kg
+    r = 1000.0 * u.km
+    end_lambda = 1000.0
+    stepsize = 0.5
     tmp = _G * M.value / _cc
     q = tmp * u.C / u.kg
     print(tmp, 5.900455 * tmp ** 3)
@@ -70,22 +71,20 @@ def test_calculate_trajectory1(M, r, end_lambda, stepsize):
     assert_allclose(ans[1][0][1], ans[1][-1][1], 1e-2)
 
 
-@pytest.mark.parametrize(
-    "pos_vec, vel_vec, q, M, a, Q, el, ss",
-    [
-        (
-            [1000.0 * u.km, 0.6 * np.pi * u.rad, np.pi / 8 * u.rad],
-            [10000 * u.m / u.s, -0.01 * u.rad / u.s, 0.0 * u.rad / u.s],
-            1 * u.C / u.g,
-            0.5 * 5.972e24 * u.kg,
-            1e-6,
-            100 * u.C,
-            200.0,
-            1.0,
-        )
-    ],
-)
-def test_compare_calculate_trajectory_iterator_bl(pos_vec, vel_vec, q, M, a, Q, el, ss):
+@pytest.fixture()
+def test_input():
+    q = 1 * u.C / u.g
+    a = 1e-6
+    Q = 100 * u.C
+    el = 200.0
+    ss = 1.0
+    return (q, a, Q, el, ss)
+
+def test_compare_calculate_trajectory_iterator_bl(test_input):
+    pos_vec = [1000.0 * u.km, 0.6 * np.pi * u.rad, np.pi / 8 * u.rad]
+    vel_vec = [10000 * u.m / u.s, -0.01 * u.rad / u.s, 0.0 * u.rad / u.s]
+    M = 0.5 * 5.972e24 * u.kg
+    q, a, Q, el, ss = test_input
     cl1 = KerrNewman.from_BL(pos_vec, vel_vec, q, 0 * u.s, M, a, Q)
     cl2 = KerrNewman.from_BL(pos_vec, vel_vec, q, 0 * u.s, M, a, Q)
     ans1 = cl1.calculate_trajectory(end_lambda=el, OdeMethodKwargs={"stepsize": ss})[1]
@@ -98,24 +97,11 @@ def test_compare_calculate_trajectory_iterator_bl(pos_vec, vel_vec, q, M, a, Q, 
     assert_allclose(ans1[:20], ans2)
 
 
-@pytest.mark.parametrize(
-    "pos_vec, vel_vec, q, M, a, Q, el, ss",
-    [
-        (
-            [1000000 * u.m, 1000000 * u.m, 20.5 * u.m],
-            [10000 * u.m / u.s, 10000 * u.m / u.s, -30 * u.m / u.s],
-            1 * u.C / u.g,
-            2e24 * u.kg,
-            1e-6,
-            100 * u.C,
-            200.0,
-            1.0,
-        )
-    ],
-)
-def test_compare_calculate_trajectory_iterator_cartesians(
-    pos_vec, vel_vec, q, M, a, Q, el, ss
-):
+def test_compare_calculate_trajectory_iterator_cartesians(test_input):
+    pos_vec = [1000000 * u.m, 1000000 * u.m, 20.5 * u.m]
+    vel_vec = [10000 * u.m / u.s, 10000 * u.m / u.s, -30 * u.m / u.s]
+    M = 2e24 * u.kg
+    q, a, Q, el, ss = test_input
     cl1 = KerrNewman.from_cartesian(pos_vec, vel_vec, q, 0 * u.s, M, a, Q)
     cl2 = KerrNewman.from_cartesian(pos_vec, vel_vec, q, 0 * u.s, M, a, Q)
     ans1 = cl1.calculate_trajectory(

--- a/src/einsteinpy/tests/test_metric/test_kerrnewman.py
+++ b/src/einsteinpy/tests/test_metric/test_kerrnewman.py
@@ -80,6 +80,7 @@ def test_input():
     ss = 1.0
     return (q, a, Q, el, ss)
 
+
 def test_compare_calculate_trajectory_iterator_bl(test_input):
     pos_vec = [1000.0 * u.km, 0.6 * np.pi * u.rad, np.pi / 8 * u.rad]
     vel_vec = [10000 * u.m / u.s, -0.01 * u.rad / u.s, 0.0 * u.rad / u.s]

--- a/src/einsteinpy/tests/test_metric/test_kerrnewman.py
+++ b/src/einsteinpy/tests/test_metric/test_kerrnewman.py
@@ -78,7 +78,7 @@ def test_input():
     Q = 100 * u.C
     el = 200.0
     ss = 1.0
-    return (q, a, Q, el, ss)
+    return q, a, Q, el, ss
 
 
 def test_compare_calculate_trajectory_iterator_bl(test_input):

--- a/src/einsteinpy/tests/test_utils/test_bl_coord_transforms.py
+++ b/src/einsteinpy/tests/test_utils/test_bl_coord_transforms.py
@@ -6,64 +6,36 @@ from numpy.testing import assert_allclose
 from einsteinpy import utils
 
 
-@pytest.mark.parametrize(
-    "pos_vec, a, ans_vec",
-    [
-        (
-            np.array([20.0, 311.0, 210.0]),
-            0.0,
-            np.array([375.79382645275, 0.9778376650369, 1.5065760775947]),
-        )
-    ],
-)
-def test_CartesianToBL_pos(pos_vec, a, ans_vec):
+def test_CartesianToBL_pos():
+    pos_vec = np.array([20.0, 311.0, 210.0])
+    a = 0.0
+    ans_vec = np.array([375.79382645275, 0.9778376650369, 1.5065760775947])
     ans = utils.CartesianToBL_pos(pos_vec, a)
     assert_allclose(ans, ans_vec, rtol=0.0, atol=1e-5)
 
 
-@pytest.mark.parametrize(
-    "pos_vec, a, ans_vec",
-    [
-        (
-            np.array([12, 20 * np.pi / 180, 60 * np.pi / 180]),
-            0.0,
-            np.array([2.052121, 3.55437, 11.27631]),
-        )
-    ],
-)
-def test_BLtoCartesian_pos(pos_vec, a, ans_vec):
+def test_BLtoCartesian_pos():
+    pos_vec = np.array([12, 20 * np.pi / 180, 60 * np.pi / 180])
+    a = 0.0
+    ans_vec = np.array([2.052121, 3.55437, 11.27631])
     ans = utils.BLToCartesian_pos(pos_vec, a)
     assert_allclose(ans, ans_vec, rtol=0.0, atol=1e-5)
 
 
-@pytest.mark.parametrize(
-    "pos_vec, vel_vec, a, ans_vec",
-    [
-        (
-            np.array([10 / np.sqrt(2), 10 / np.sqrt(2), 0.0]),
-            np.array([-190 / np.sqrt(2), 210 / np.sqrt(2), 200.0]),
-            0.0,
-            np.array([10.0, -20.0, 20.0]),
-        )
-    ],
-)
-def test_CartesianToBL_vel(pos_vec, vel_vec, a, ans_vec):
+def test_CartesianToBL_vel():
+    pos_vec = np.array([10 / np.sqrt(2), 10 / np.sqrt(2), 0.0])
+    vel_vec = np.array([-190 / np.sqrt(2), 210 / np.sqrt(2), 200.0])
+    a = 0.0
+    ans_vec = np.array([10.0, -20.0, 20.0])
     ans = utils.CartesianToBL_vel(pos_vec, vel_vec, a)
     assert_allclose(ans, ans_vec, rtol=0.0, atol=1e-5)
 
 
-@pytest.mark.parametrize(
-    "pos_vec, vel_vec, a, ans_vec",
-    [
-        (
-            np.array([20, np.pi / 2, np.pi / 4]),
-            np.array([0.0, 0.0, 10]),
-            0.0,
-            np.array([-200 / np.sqrt(2), 200 / np.sqrt(2), 0]),
-        )
-    ],
-)
-def test_BLtoCartesian_vel(pos_vec, vel_vec, a, ans_vec):
+def test_BLtoCartesian_vel():
+    pos_vec = np.array([20, np.pi / 2, np.pi / 4])
+    vel_vec = np.array([0.0, 0.0, 10])
+    a = 0.0
+    ans_vec = np.array([-200 / np.sqrt(2), 200 / np.sqrt(2), 0])
     ans = utils.BLToCartesian_vel(pos_vec, vel_vec, a)
     assert_allclose(ans, ans_vec, rtol=0.0, atol=1e-5)
 
@@ -105,39 +77,25 @@ def test_cycle_vel(pos_vec, vel_vec, a):
     assert_allclose(vel_vec, vel_vec3, rtol=0.0, atol=1e-5)
 
 
-@pytest.mark.parametrize(
-    "pos_vec, vel_vec, a, ans_vel_vec",
-    [
-        (
-            [20 * u.m, 90 * u.deg, 45 * u.deg],
-            [0.0 * u.km / u.s, 0.0 * u.rad / u.s, 10 * u.rad / u.s],
-            0.0,
-            np.array([-200 / np.sqrt(2), 200 / np.sqrt(2), 0]),
-        )
-    ],
-)
-def test_BL2C_units(pos_vec, vel_vec, a, ans_vel_vec):
+def test_BL2C_units():
+    pos_vec = [20 * u.m, 90 * u.deg, 45 * u.deg]
+    vel_vec = [0.0 * u.km / u.s, 0.0 * u.rad / u.s, 10 * u.rad / u.s]
+    a = 0.0
+    ans_vel_vec = np.array([-200 / np.sqrt(2), 200 / np.sqrt(2), 0])
     a = utils.BL2C_units(pos_vec, vel_vec, a)
     tmp = np.array([t.value for t in a[1]])
     assert_allclose(ans_vel_vec, tmp, rtol=0.0, atol=1e-5)
 
 
-@pytest.mark.parametrize(
-    "vec, a",
-    [
-        (
-            np.array(
-                [
-                    [21.0, 300, 0.33, 4.0, 1.0, -10.0, -1, -2],
-                    [1.0, 3, 0.1, 5.0, 1.0, 100.0, -11, 2],
-                    [1.0, 3, 0.1, 0, 1.0, 0, -11, 2],
-                ]
-            ),
-            0.4,
-        )
-    ],
-)
-def test_BL2C_8dim(vec, a):
+def test_BL2C_8dim():
+    vec = np.array(
+        [
+            [21.0, 300, 0.33, 4.0, 1.0, -10.0, -1, -2],
+            [1.0, 3, 0.1, 5.0, 1.0, 100.0, -11, 2],
+            [1.0, 3, 0.1, 0, 1.0, 0, -11, 2],
+        ]
+    )
+    a = 0.4
     list1 = list()
     for v in vec:
         nv = np.hstack(

--- a/src/einsteinpy/tests/test_utils/test_coord_transforms.py
+++ b/src/einsteinpy/tests/test_utils/test_coord_transforms.py
@@ -5,79 +5,44 @@ from numpy.testing import assert_allclose
 from einsteinpy import utils
 
 
-@pytest.mark.parametrize(
-    "pos_vec, ans_vec",
-    [
-        (
-            np.array([20.0, 311.0, 210.0]),
-            np.array([375.79382645275, 0.9778376650369, 1.5065760775947]),
-        )
-    ],
-)
-def test_CartesianToSpherical_pos(pos_vec, ans_vec):
+def test_CartesianToSpherical_pos():
+    pos_vec = np.array([20.0, 311.0, 210.0])
+    ans_vec = np.array([375.79382645275, 0.9778376650369, 1.5065760775947])
     ans = utils.CartesianToSpherical_pos(pos_vec)
     assert_allclose(ans, ans_vec, rtol=0.0, atol=1e-5)
 
 
-@pytest.mark.parametrize(
-    "pos_vec, ans_vec",
-    [
-        (
-            np.array([12, 20 * np.pi / 180, 60 * np.pi / 180]),
-            np.array([2.052121, 3.55437, 11.27631]),
-        )
-    ],
-)
-def test_SphericalToCartesian_pos(pos_vec, ans_vec):
+def test_SphericalToCartesian_pos():
+    pos_vec = np.array([12, 20 * np.pi / 180, 60 * np.pi / 180])
+    ans_vec = np.array([2.052121, 3.55437, 11.27631])
     ans = utils.SphericalToCartesian_pos(pos_vec)
     assert_allclose(ans, ans_vec, rtol=0.0, atol=1e-5)
 
 
-@pytest.mark.parametrize(
-    "pos_vec, vel_vec, ans_vec",
-    [
-        (
-            np.array([20, np.pi / 2, np.pi / 4]),
-            np.array([0.0, 0.0, 10]),
-            np.array([-200 / np.sqrt(2), 200 / np.sqrt(2), 0]),
-        )
-    ],
-)
-def test_SphericalToCartesian_vel(pos_vec, vel_vec, ans_vec):
+def test_SphericalToCartesian_vel():
+    pos_vec = np.array([20, np.pi / 2, np.pi / 4])
+    vel_vec = np.array([0.0, 0.0, 10])
+    ans_vec = np.array([-200 / np.sqrt(2), 200 / np.sqrt(2), 0])
     ans = utils.SphericalToCartesian_vel(pos_vec, vel_vec)
     assert_allclose(ans, ans_vec, rtol=0.0, atol=1e-5)
 
 
-@pytest.mark.parametrize(
-    "pos_vec, vel_vec, ans_vec",
-    [
-        (
-            np.array([10 / np.sqrt(2), 10 / np.sqrt(2), 0.0]),
-            np.array([-190 / np.sqrt(2), 210 / np.sqrt(2), 200.0]),
-            np.array([10.0, -20.0, 20.0]),
-        )
-    ],
-)
-def test_CartesianToSpherical_vel(pos_vec, vel_vec, ans_vec):
+def test_CartesianToSpherical_vel():
+    pos_vec = np.array([10 / np.sqrt(2), 10 / np.sqrt(2), 0.0])
+    vel_vec = np.array([-190 / np.sqrt(2), 210 / np.sqrt(2), 200.0])
+    ans_vec = np.array([10.0, -20.0, 20.0])
     ans = utils.CartesianToSpherical_vel(pos_vec, vel_vec)
     assert_allclose(ans, ans_vec, rtol=0.0, atol=1e-5)
 
 
-@pytest.mark.parametrize(
-    "vec",
-    [
-        (
-            np.array(
-                [
-                    [21.0, 300, 0.33, 4.0, 1.0, -10.0, -1, -2],
-                    [1.0, 3, 0.1, 5.0, 1.0, 100.0, -11, 2],
-                    [1.0, 3, 0.1, 0, 1.0, 0, -11, 2],
-                ]
-            )
-        )
-    ],
-)
-def test_S2C_8dim(vec):
+def test_S2C_8dim():
+    vec = np.array(
+        [
+            [21.0, 300, 0.33, 4.0, 1.0, -10.0, -1, -2],
+            [1.0, 3, 0.1, 5.0, 1.0, 100.0, -11, 2],
+            [1.0, 3, 0.1, 0, 1.0, 0, -11, 2],
+        ]
+    )
     list1 = list()
     for v in vec:
         nv = np.hstack(

--- a/src/einsteinpy/tests/test_utils/test_kerr_utils.py
+++ b/src/einsteinpy/tests/test_utils/test_kerr_utils.py
@@ -40,9 +40,13 @@ def test_radius_ergosphere_for_nonrotating_case():
     assert_allclose(a1[0], _scr, rtol=0.0, atol=1e-5)
 
 
-@pytest.mark.parametrize("c, r, theta, Rs, a", [(3e8, 100.0, np.pi / 5, 1.0, 0.2)])
-def test_christoffels(c, r, theta, Rs, a):
+def test_christoffels():
     # output produced by the optimized function
+    c = 3e8
+    r = 100.0
+    theta = np.pi / 5
+    Rs = 1.0
+    a = 0.2
     chl1 = kerr_utils.christoffels(c, r, theta, Rs, a)
     # calculate by formula
     invg = kerr_utils.metric_inv(c, r, theta, Rs, a)
@@ -70,8 +74,8 @@ def test_scaled_spin_factor_raises_error(a):
         assert True
 
 
-@pytest.mark.parametrize("a", [0.8])
-def test_scaled_spin_factor(a):
+def test_scaled_spin_factor():
+    a = 0.8
     M = 5e24 * u.kg
     a1 = kerr_utils.scaled_spin_factor(a, M.value)
     a2 = utils.schwarzschild_radius(M).value * a * 0.5

--- a/src/einsteinpy/tests/test_utils/test_kerrnewman_utils.py
+++ b/src/einsteinpy/tests/test_utils/test_kerrnewman_utils.py
@@ -20,7 +20,7 @@ def test_input():
     theta = 4 * np.pi / 5
     M = 1e23
     a = 0.99
-    return (c, G, Cc, r, theta, M, a)
+    return c, G, Cc, r, theta, M, a
 
 
 def test_compare_kerr_kerrnewman_metric_inv(test_input):

--- a/src/einsteinpy/tests/test_utils/test_kerrnewman_utils.py
+++ b/src/einsteinpy/tests/test_utils/test_kerrnewman_utils.py
@@ -10,13 +10,20 @@ _c = constant.c.value
 _G = constant.G.value
 _cc = constant.coulombs_const.value
 
-cos, sin = np.cos, np.sin
 
+@pytest.fixture()
+def test_input():
+    c = _c
+    G = _G
+    Cc = _cc
+    r = 0.1
+    theta = 4 * np.pi / 5
+    M = 1e23
+    a = 0.99
+    return (c, G, Cc, r, theta, M, a)
 
-@pytest.mark.parametrize(
-    "c, G, Cc, r, theta, M, a", [(_c, _G, _cc, 0.1, 4 * np.pi / 5, 1e23, 0.99)]
-)
-def test_compare_kerr_kerrnewman_metric_inv(c, G, Cc, r, theta, M, a):
+def test_compare_kerr_kerrnewman_metric_inv(test_input):
+    c, G, Cc, r, theta, M, a = test_input
     # inverse of metric for kerr and kerr-newman metric should be equal when Q=0
     scr = M * G / (c ** 2)
     a_scaled = kerr_utils.scaled_spin_factor(a, M, c, G)
@@ -25,10 +32,8 @@ def test_compare_kerr_kerrnewman_metric_inv(c, G, Cc, r, theta, M, a):
     assert_allclose(m1, m2, rtol=1e-10)
 
 
-@pytest.mark.parametrize(
-    "c, G, Cc, r, theta, M, a", [(_c, _G, _cc, 0.1, 4 * np.pi / 5, 1e23, 0.99)]
-)
-def test_compare_kerr_kerrnewman_dmetric_dx(c, G, Cc, r, theta, M, a):
+def test_compare_kerr_kerrnewman_dmetric_dx(test_input):
+    c, G, Cc, r, theta, M, a = test_input
     # differentiation of metric for kerr and kerr-newman metric should be equal when Q=0
     scr = M * G / (c ** 2)
     a_scaled = kerr_utils.scaled_spin_factor(a, M, c, G)
@@ -37,11 +42,10 @@ def test_compare_kerr_kerrnewman_dmetric_dx(c, G, Cc, r, theta, M, a):
     assert_allclose(m1, m2, rtol=1e-10)
 
 
-@pytest.mark.parametrize(
-    "c, G, Cc, r, theta, M, a, Q", [(_c, _G, _cc, 0.1, 4 * np.pi / 5, 1e23, 0.99, 1.0)]
-)
-def test_christoffels1(c, G, Cc, r, theta, M, a, Q):
+def test_christoffels1(test_input):
     # compare christoffel symbols output by optimized function and by brute force
+    c, G, Cc, r, theta, M, a  = test_input
+    Q = 1.0
     scr = M * G / (c ** 2)
     a_scaled = kerr_utils.scaled_spin_factor(a, M, c, G)
     chl1 = kerrnewman_utils.christoffels(c, G, Cc, r, theta, scr, a_scaled, Q)
@@ -62,11 +66,9 @@ def test_christoffels1(c, G, Cc, r, theta, M, a, Q):
     assert_allclose(chl2, chl1, rtol=1e-10)
 
 
-@pytest.mark.parametrize(
-    "c, G, Cc, r, theta, M, a", [(_c, _G, _cc, 0.1, 4 * np.pi / 5, 1e23, 0.99)]
-)
-def test_compare_kerr_kerrnewman_christoffels(c, G, Cc, r, theta, M, a):
+def test_compare_kerr_kerrnewman_christoffels(test_input):
     # christoffel symbols for kerr and kerr-newman metric should be equal when Q=0
+    c, G, Cc, r, theta, M, a = test_input
     scr = M * G / (c ** 2)
     a_scaled = kerr_utils.scaled_spin_factor(a, M, c, G)
     c1 = kerr_utils.christoffels(c, r, theta, scr, a_scaled)
@@ -74,29 +76,21 @@ def test_compare_kerr_kerrnewman_christoffels(c, G, Cc, r, theta, M, a):
     assert_allclose(c1, c2, rtol=1e-8)
 
 
-@pytest.mark.parametrize(
-    "c, G, Cc, r, theta, M, Q", [(_c, _G, _cc, 0.1, 4 * np.pi / 5, 1e23, 15.5)]
-)
-def test_electric_magnetic_potential_from_em_potential_vector(c, G, Cc, r, theta, M, Q):
+def test_electric_magnetic_potential_from_em_potential_vector(test_input):
+    c, G, Cc, r, theta, M, a = test_input
+    Q = 15.5
     vec = kerrnewman_utils.em_potential(c, G, Cc, r, theta, 0.0, Q, M)
     cmparr = np.zeros((4,), dtype=float)
     cmparr[0] = (Q / ((c ** 2) * r)) * np.sqrt(G * constant.coulombs_const.value)
     assert_allclose(cmparr, vec, rtol=1e-8)
 
 
-@pytest.mark.parametrize(
-    "pos_vec, vel_vec, mass, a01",
-    [
-        (
-            np.array([1.0, np.pi / 2, 0.1]),
-            np.array([-0.1, -0.01, 0.05]),
-            1e24 * u.kg,
-            0.85,
-        )
-    ],
-)
-def test_compare_kerr_kerrnewman_time_velocity(pos_vec, vel_vec, mass, a01):
+def test_compare_kerr_kerrnewman_time_velocity():
     # time velocity for kerr & kerr-newman should be same when Q=0
+    pos_vec = np.array([1.0, np.pi / 2, 0.1])
+    vel_vec = np.array([-0.1, -0.01, 0.05])
+    mass = 1e24 * u.kg
+    a01 = 0.85
     a = kerr_utils.scaled_spin_factor(
         a01, mass.to(u.kg).value, constant.c.value, constant.G.value
     )
@@ -105,24 +99,28 @@ def test_compare_kerr_kerrnewman_time_velocity(pos_vec, vel_vec, mass, a01):
     assert_allclose(t1.value, t2.value, rtol=1e-10)
 
 
-@pytest.mark.parametrize("M, r, theta, Q, a", [(2e22, 1.5, 3 * np.pi / 5, 10.0, 0.5)])
-def test_maxwell_tensor_covariant_for_natural_units(M, r, theta, Q, a):
+def test_maxwell_tensor_covariant_for_natural_units():
     # formula for testing from https://arxiv.org/abs/gr-qc/0409025
+    M = 2e22
+    r = 1.5
+    theta = 3 * np.pi / 5
+    Q = 10.0
+    a = 0.5
     m = kerrnewman_utils.maxwell_tensor_covariant(1.0, 1.0, 1.0, r, theta, a, Q, M)
     for t in range(16):
         i = int(t / 4) % 4
         j = t % 4
         assert_allclose(0, m[i, j] + m[j, i], rtol=0.0, atol=1e-10)
     th, r2, a2 = theta, r ** 2, a ** 2
-    E_r = Q * (r2 - (a * cos(th)) ** 2) / ((r2 + (a * cos(th)) ** 2) ** 2)
-    E_th = (a2) * (-Q) * sin(2 * th) / ((r2 + (a * cos(th)) ** 2) ** 2)
-    B_r = 2 * a * Q * (r2 + a2) * cos(th) / (r * ((r2 + (a * cos(th)) ** 2) ** 2))
+    E_r = Q * (r2 - (a * np.cos(th)) ** 2) / ((r2 + (a * np.cos(th)) ** 2) ** 2)
+    E_th = (a2) * (-Q) * np.sin(2 * th) / ((r2 + (a * np.cos(th)) ** 2) ** 2)
+    B_r = 2 * a * Q * (r2 + a2) * np.cos(th) / (r * ((r2 + (a * np.cos(th)) ** 2) ** 2))
     B_th = (
         a
         * Q
-        * sin(th)
-        * (r2 - (a * cos(th)) ** 2)
-        / (r * ((r2 + (a * cos(th)) ** 2) ** 2))
+        * np.sin(th)
+        * (r2 - (a * np.cos(th)) ** 2)
+        / (r * ((r2 + (a * np.cos(th)) ** 2) ** 2))
     )
     assert_allclose(E_r, m[0, 1], rtol=1e-8)
     assert_allclose(r * E_th, m[0, 2], rtol=1e-8)
@@ -130,9 +128,13 @@ def test_maxwell_tensor_covariant_for_natural_units(M, r, theta, Q, a):
     assert_allclose((r ** 2) * np.sin(theta) * B_r / M, m[3, 2], rtol=1e-8)
 
 
-@pytest.mark.parametrize("M, r, theta, Q, a", [(1e22, 5.5, 2 * np.pi / 5, 45.0, 0.7)])
-def test_maxwell_tensor_contravariant_for_natural_units(M, r, theta, Q, a):
+def test_maxwell_tensor_contravariant_for_natural_units():
     # Theoritical background required to write extensive test. Right now only skew-symettric property is being checked.
+    M = 1e22
+    r = 5.5
+    theta = 2 * np.pi / 5
+    Q = 45.0
+    a = 0.7
     m = kerrnewman_utils.maxwell_tensor_contravariant(1.0, 1.0, 1.0, r, theta, a, Q, M)
     for t in range(16):
         i = int(t / 4) % 4

--- a/src/einsteinpy/tests/test_utils/test_kerrnewman_utils.py
+++ b/src/einsteinpy/tests/test_utils/test_kerrnewman_utils.py
@@ -22,6 +22,7 @@ def test_input():
     a = 0.99
     return (c, G, Cc, r, theta, M, a)
 
+
 def test_compare_kerr_kerrnewman_metric_inv(test_input):
     c, G, Cc, r, theta, M, a = test_input
     # inverse of metric for kerr and kerr-newman metric should be equal when Q=0
@@ -44,7 +45,7 @@ def test_compare_kerr_kerrnewman_dmetric_dx(test_input):
 
 def test_christoffels1(test_input):
     # compare christoffel symbols output by optimized function and by brute force
-    c, G, Cc, r, theta, M, a  = test_input
+    c, G, Cc, r, theta, M, a = test_input
     Q = 1.0
     scr = M * G / (c ** 2)
     a_scaled = kerr_utils.scaled_spin_factor(a, M, c, G)

--- a/src/einsteinpy/tests/test_utils/test_schwarzschild_utils.py
+++ b/src/einsteinpy/tests/test_utils/test_schwarzschild_utils.py
@@ -10,8 +10,10 @@ _c = constant.c.value
 _G = constant.G.value
 
 
-@pytest.mark.parametrize("r, theta, Rs", [(99.9, 5 * np.pi / 6, 9e-3)])
-def test_compare_kerr_and_schwarzschild_metric(r, theta, Rs):
+def test_compare_kerr_and_schwarzschild_metric():
+    r = 99.9
+    theta = 5 * np.pi / 6
+    Rs = 9e-3
     # Kerr metric would reduce to Schwarzschild metric under limits a=0
     mk = kerr_utils.metric(_c, r, theta, Rs, 0.0)
     ms = schwarzschild_utils.metric(_c, r, theta, Rs)


### PR DESCRIPTION
Fixes #142 

This pull request removes redundant parameters using fixtures and the unnecessary parametrize decorators by adding the parameters in the test functions itself. 

@shreyasbapat, kindly review it.
