### PR TITLE
refactor: Move ScatterGeodesicsPlotter to new file.

### DIFF
--- a/src/einsteinpy/plotting/__init__.py
+++ b/src/einsteinpy/plotting/__init__.py
@@ -1,1 +1,2 @@
-from .geodesics_static import ScatterGeodesicPlotter, StaticGeodesicPlotter
+from .geodesics_scatter import ScatterGeodesicPlotter
+from .geodesics_static import StaticGeodesicPlotter

--- a/src/einsteinpy/plotting/geodesics_scatter.py
+++ b/src/einsteinpy/plotting/geodesics_scatter.py
@@ -1,0 +1,47 @@
+import astropy.units as u
+import matplotlib.pyplot as plt
+import numpy as np
+
+from einsteinpy.metric import Schwarzschild
+
+
+class ScatterGeodesicPlotter:
+    """
+    Class for plotting static matplotlib plots.
+    """
+
+    def __init__(self, mass, time=0 * u.s):
+        self.mass = mass
+        self.time = time
+        self._attractor_present = False
+
+    def _plot_attractor(self):
+        self._attractor_present = True
+        plt.scatter(0, 0, color="black")
+
+    def plot(self, pos_vec, vel_vec, end_lambda=10, step_size=1e-3):
+        swc = Schwarzschild.from_spherical(pos_vec, vel_vec, self.time, self.mass)
+
+        vals = swc.calculate_trajectory(
+            end_lambda=end_lambda, OdeMethodKwargs={"stepsize": step_size}
+        )[1]
+
+        time = vals[:, 0]
+        r = vals[:, 1]
+        # Currently not being used (might be useful in future)
+        # theta = vals[:, 2]
+        phi = vals[:, 3]
+
+        pos_x = r * np.cos(phi)
+        pos_y = r * np.sin(phi)
+
+        plt.scatter(pos_x, pos_y, s=1, c=time, cmap="Oranges")
+
+        if not self._attractor_present:
+            self._plot_attractor()
+
+    def show(self):
+        plt.show()
+
+    def save(self, name="scatter_geodesic.png"):
+        plt.savefig(name)

--- a/src/einsteinpy/plotting/geodesics_static.py
+++ b/src/einsteinpy/plotting/geodesics_static.py
@@ -9,48 +9,6 @@ from einsteinpy.metric import Schwarzschild
 from einsteinpy.utils import schwarzschild_radius
 
 
-class ScatterGeodesicPlotter:
-    """
-    Class for plotting static matplotlib plots.
-    """
-
-    def __init__(self, mass, time=0 * u.s):
-        self.mass = mass
-        self.time = time
-        self._attractor_present = False
-
-    def _plot_attractor(self):
-        self._attractor_present = True
-        plt.scatter(0, 0, color="black")
-
-    def plot(self, pos_vec, vel_vec, end_lambda=10, step_size=1e-3):
-        swc = Schwarzschild.from_spherical(pos_vec, vel_vec, self.time, self.mass)
-
-        vals = swc.calculate_trajectory(
-            end_lambda=end_lambda, OdeMethodKwargs={"stepsize": step_size}
-        )[1]
-
-        time = vals[:, 0]
-        r = vals[:, 1]
-        # Currently not being used (might be useful in future)
-        # theta = vals[:, 2]
-        phi = vals[:, 3]
-
-        pos_x = r * np.cos(phi)
-        pos_y = r * np.sin(phi)
-
-        plt.scatter(pos_x, pos_y, s=1, c=time, cmap="Oranges")
-
-        if not self._attractor_present:
-            self._plot_attractor()
-
-    def show(self):
-        plt.show()
-
-    def save(self, name="scatter_geodesic.png"):
-        plt.savefig(name)
-
-
 class StaticGeodesicPlotter:
     """
     Class for plotting static matplotlib plots

--- a/src/einsteinpy/tests/test_plotting/test_scattergeodesicplotter.py
+++ b/src/einsteinpy/tests/test_plotting/test_scattergeodesicplotter.py
@@ -28,7 +28,7 @@ def test_plot_attractor_is_called_only_once(dummy_data):
 
 
 @mock.patch(
-    "einsteinpy.plotting.geodesics_static.ScatterGeodesicPlotter._plot_attractor"
+    "einsteinpy.plotting.geodesics_scatter.ScatterGeodesicPlotter._plot_attractor"
 )
 def test_plot_calls_plot_attractor(mock_plot_attractor):
     r = [306 * u.m, np.pi / 2 * u.rad, np.pi / 2 * u.rad]
@@ -41,7 +41,7 @@ def test_plot_calls_plot_attractor(mock_plot_attractor):
     mock_plot_attractor.assert_called_with()
 
 
-@mock.patch("einsteinpy.plotting.geodesics_static.plt.show")
+@mock.patch("einsteinpy.plotting.geodesics_scatter.plt.show")
 def test_plot_show_shows_plot(mock_show):
     r = [306 * u.m, np.pi / 2 * u.rad, np.pi / 2 * u.rad]
     v = [0 * u.m / u.s, 0 * u.rad / u.s, 951.0 * u.rad / u.s]
@@ -54,7 +54,7 @@ def test_plot_show_shows_plot(mock_show):
     mock_show.assert_called_with()
 
 
-@mock.patch("einsteinpy.plotting.geodesics_static.plt.savefig")
+@mock.patch("einsteinpy.plotting.geodesics_scatter.plt.savefig")
 def test_plot_save_saves_plot(mock_save):
     r = [306 * u.m, np.pi / 2 * u.rad, np.pi / 2 * u.rad]
     v = [0 * u.m / u.s, 0 * u.rad / u.s, 951.0 * u.rad / u.s]


### PR DESCRIPTION
Fixes: #178.

Move class `ScatterGeodesicsPlotter` to a new file `geodesics_scatter.py` and edit the tests for the change.