### PR TITLE
Restructure & Add/Update tests for coordinates module

### DIFF
--- a/docs/source/metric.rst
+++ b/docs/source/metric.rst
@@ -25,7 +25,7 @@ by :
 
   * :math:`ds^2 = g_{ij}dx_{i}dx_{j}`
 
-The tensor is constructed when each :math:`a_{ij}` is put in it's 
+The tensor is constructed when each :math:`g_{ij}` is put in it's 
 position in a rank-2 tensor. For example, metric tensor in a spherical 
 coordinate system is given by:
 
@@ -48,8 +48,8 @@ experience the curvature, as after a long journey, he would come back
 at the position where he started. For him space is not infinite. 
 
 Mathematically, curvature of a space is given by Riemann Curvature Tensor, 
-whose contraction is Ricii Tensor, and further contraction yields a scalar 
-called Ricci Scalar of Curvature Scalar. 
+whose contraction is Ricii Tensor, and taking its trace yields a scalar 
+called Ricci Scalar or Curvature Scalar. 
 
 Straight lines in Curved Space
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,13 +61,13 @@ curved) space.
 Mathematically, geodesics are calculated by solving set of differential equation 
 for each space(time) component using the equation:
 
-  * :math:`\ddot{x}_i+0.5g_{im}(\partial_{l}g_{mk}+\partial_{k}g_{ml}-\partial_{m}g_{kl})\dot{x}_k\dot{x}_l = 0`
+  * :math:`\ddot{x}_i+0.5*g^{im}*(\partial_{l}g_{mk}+\partial_{k}g_{ml}-\partial_{m}g_{kl})\dot{x}_k\dot{x}_l = 0`
   
     which can be re-written as 
 
   * :math:`\ddot{x}_i+\Gamma_{kl}^i \dot{x}_k\dot{x}_l = 0`
 
-    where :math:`\Gamma` is Christoffel symbol of second kind.
+    where :math:`\Gamma` is Christoffel symbol of the second kind.
 
 Christoffel symbols can be encapsulated in a rank-3 tensor which is symmetric 
 over it's lower indices. Coming back to Riemann Curvature Tensor, which is derived 
@@ -77,8 +77,8 @@ from Christoffel symbols using the equation
 
 Of course, Einstein's indicial notation applies everywhere.
 
-Contraction of Riemann Tensor gives us Ricci Tensor, which on further 
-contraction gives Ricci or Curvature scalar. A space with no curvature 
+Contraction of Riemann Tensor gives us Ricci Tensor, on which taking trace 
+gives Ricci or Curvature scalar. A space with no curvature 
 has Riemann Tensor as zero.
 
 Exact Solutions of EFE
@@ -102,7 +102,7 @@ so is the case with the tidal forces. Putting :math:`r=\infty`, we see that the 
 transforms to a metric for a flat space defined by spherical coordinates. 
 
 :math:`\tau` is the proper time, the time experienced by the particle in motion in 
-the space-time while :math:`t` is the coordinate time obeserved by an observer 
+the space-time while :math:`t` is the coordinate time observed by an observer 
 at infinity.
 
 Using the metric in the above discussed geodesic equation gives the four-position 

--- a/src/einsteinpy/coordinates/__init__.py
+++ b/src/einsteinpy/coordinates/__init__.py
@@ -1,7 +1,7 @@
-from einsteinpy.coordinates.core import BoyerLindquist, Cartesian, Spherical
+from .core import BoyerLindquist, Cartesian, Spherical
 
-from einsteinpy.coordinates.velocity import (  # isort:skip
+from .velocity import (  # isort:skip
     BoyerLindquistDifferential,
     CartesianDifferential,
     SphericalDifferential,
-)  # isort: skip added because isort and black conflict on the above import, to be fixed later
+)  # isort:skip added because isort and black conflict on the above import, to be fixed later

--- a/src/einsteinpy/tests/test_coordinates/test_coord_transform.py
+++ b/src/einsteinpy/tests/test_coordinates/test_coord_transform.py
@@ -1,78 +1,123 @@
-import astropy.units as u
-import pytest
+import sys
+from io import StringIO
 
-from einsteinpy import coordinates
+import astropy.units as u
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from einsteinpy.coordinates import BoyerLindquist, Cartesian, Spherical
 
 
 @pytest.fixture()
 def cartesian():
-    return coordinates.Cartesian(20.0 * u.km, 311.0 * u.km, 210.0 * u.km)
+    return Cartesian(20.0 * u.km, 311e3 * u.m, 210e5 * u.cm)
 
 
 @pytest.fixture()
 def spherical():
-    return coordinates.Spherical(
+    return Spherical(
         375.79382645275 * u.km, 0.9778376650369 * u.rad, 1.5065760775947 * u.rad
     )
 
 
 @pytest.fixture()
 def boyerlindquist():
-    return (
-        coordinates.BoyerLindquist(
-            375.79382645275 * u.km, 0.9778376650369 * u.rad, 1.5065760775947 * u.rad
-        ),
-        0.0 * u.km,
+    return BoyerLindquist(
+        375.79382645275 * u.km,
+        0.9778376650369 * u.rad,
+        1.5065760775947 * u.rad,
+        0.0 * u.cm,
     )
-
-
-def assert_cartesian(cartesian, to_cartesian):
-    assert abs(to_cartesian.x - cartesian.x) <= (1e-5) * u.km
-    assert abs(to_cartesian.y - cartesian.y) <= (1e-5) * u.km
-    assert abs(to_cartesian.z - cartesian.z) <= (1e-5) * u.km
-
-
-def assert_spherical(spherical, to_spherical):
-    assert abs(to_spherical.r - spherical.r) <= (1e-5) * u.km
-    assert abs(to_spherical.theta - spherical.theta) <= (1e-5) * u.rad
-    assert abs(to_spherical.phi - spherical.phi) <= (1e-5) * u.rad
-
-
-def assert_boyerlindquist(bl, to_bl):
-    assert abs(to_bl.r - bl.r) <= (1e-5) * u.km
-    assert abs(to_bl.theta - bl.theta) <= (1e-5) * u.rad
-    assert abs(to_bl.phi - bl.phi) <= (1e-5) * u.rad
 
 
 def test_CartesianToSpherical(cartesian, spherical):
     to_spherical = cartesian.to_spherical()
-    assert_spherical(spherical, to_spherical)
+    assert_allclose(
+        to_spherical.si_values(), spherical.si_values(), rtol=0.0, atol=1e-6
+    )
 
 
 def test_CartesianToBoyerLindquist(cartesian, boyerlindquist):
-    bl, a = boyerlindquist
-    to_bl = cartesian.to_bl(a)
-    assert_boyerlindquist(bl, to_bl)
+    bl = boyerlindquist
+    to_bl = cartesian.to_bl(bl.a)
+    assert_allclose(to_bl.si_values(), bl.si_values(), rtol=0.0, atol=1e-6)
 
 
 def test_SphericalToCartesian(spherical, cartesian):
     to_cartesian = spherical.to_cartesian()
-    assert_cartesian(cartesian, to_cartesian)
+    assert_allclose(
+        to_cartesian.si_values(), cartesian.si_values(), rtol=0.0, atol=1e-6
+    )
 
 
 def test_SphericalToBoyerLindquist(spherical, boyerlindquist):
-    bl, a = boyerlindquist
-    to_bl = spherical.to_bl(a)
-    assert_boyerlindquist(bl, to_bl)
+    bl = boyerlindquist
+    to_bl = spherical.to_bl(bl.a)
+    assert_allclose(to_bl.si_values(), bl.si_values(), rtol=0.0, atol=1e-6)
 
 
 def test_BoyerLindquistToCartesian(boyerlindquist, cartesian):
-    bl, a = boyerlindquist
-    to_cartesian = bl.to_cartesian(a)
-    assert_cartesian(cartesian, to_cartesian)
+    bl = boyerlindquist
+    to_cartesian = bl.to_cartesian()
+    assert_allclose(
+        to_cartesian.si_values(), cartesian.si_values(), rtol=0.0, atol=1e-6
+    )
 
 
 def test_BoyerLindquistToSpherical(boyerlindquist, spherical):
-    bl, a = boyerlindquist
-    to_spherical = bl.to_spherical(a)
-    assert_spherical(spherical, to_spherical)
+    bl = boyerlindquist
+    to_spherical = bl.to_spherical()
+    assert_allclose(
+        to_spherical.si_values(), spherical.si_values(), rtol=0.0, atol=1e-6
+    )
+
+
+@pytest.mark.parametrize(
+    "cart, a",
+    [
+        (Cartesian(10 * u.m, 10 * u.m, 0 * u.m), 0.7 * u.m),
+        (Cartesian(-732.0 * u.km, 456 * u.km, -90 * u.km), 9.0 * u.km),
+        (Cartesian(-0.732 * u.km, -1.456 * u.km, 90 * u.m), 21 * u.m),
+        (Cartesian(2 * u.m, -1 * u.m, 0 * u.cm), 0 * u.cm),
+    ],
+)
+def test_cycle_CartesianBL(cart, a):
+    bl = cart.to_bl(a)
+    cart2 = bl.to_cartesian()
+    assert_allclose(cart2.si_values(), cart.si_values(), rtol=0.0, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "bl",
+    [
+        BoyerLindquist(3 * u.m, 120 * u.deg, 175 * u.deg, 0.3 * u.m),
+        BoyerLindquist(100 * u.m, 1e-3 * u.rad, 0 * u.deg, 6.969 * u.m),
+    ],
+)
+def test_cycle_BLSpherical(bl):
+    sph = bl.to_spherical()
+    bl2 = sph.to_bl(bl.a)
+    assert_allclose(bl2.si_values(), bl.si_values(), rtol=0.0, atol=1e-6)
+
+
+# Tests for object.__repr__ and object.__str__
+
+
+def test_print_core_objects(cartesian, spherical, boyerlindquist):
+    old_stdout = sys.stdout
+    # change stdout
+    result = StringIO()
+    sys.stdout = result
+
+    print(str(cartesian))
+    assert "object at 0x" not in result.getvalue()
+
+    print(str(spherical))
+    assert "object at 0x" not in result.getvalue()
+
+    print(str(boyerlindquist))
+    assert "object at 0x" not in result.getvalue()
+
+    # again switch to old stdout
+    sys.stdout = old_stdout

--- a/src/einsteinpy/tests/test_coordinates/test_velocity_transform.py
+++ b/src/einsteinpy/tests/test_coordinates/test_velocity_transform.py
@@ -1,6 +1,10 @@
+import sys
+from io import StringIO
+
 import astropy.units as u
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 from einsteinpy import coordinates
 
@@ -31,120 +35,94 @@ def spherical_differential():
 
 @pytest.fixture()
 def bl_differential():
-    return (
-        coordinates.BoyerLindquistDifferential(
-            10.0 * u.km,
-            1.5707963267948966 * u.rad,
-            0.7853981633974483 * u.rad,
-            10.0 * u.km / u.s,
-            -20.0 * u.rad / u.s,
-            20.0 * u.rad / u.s,
-        ),
+    return coordinates.BoyerLindquistDifferential(
+        10.0 * u.km,
+        1.5707963267948966 * u.rad,
+        0.7853981633974483 * u.rad,
+        10.0 * u.km / u.s,
+        -20.0 * u.rad / u.s,
+        20.0 * u.rad / u.s,
         0.0 * u.km,
     )
-
-
-def assert_cartesian_pos(cartesian_differential, to_cartesian_differential):
-    assert abs(to_cartesian_differential.y - cartesian_differential.y) <= (1e-5) * u.km
-    assert abs(to_cartesian_differential.z - cartesian_differential.z) <= (1e-5) * u.km
-    assert (
-        abs(to_cartesian_differential.v_x - cartesian_differential.v_x)
-        <= (1e-5) * u.km / u.s
-    )
-
-
-def assert_cartesian_differential(cartesian_differential, to_cartesian_differential):
-    assert abs(to_cartesian_differential.x - cartesian_differential.x) <= (1e-5) * u.km
-
-    assert (
-        abs(to_cartesian_differential.v_y - cartesian_differential.v_y)
-        <= (1e-5) * u.km / u.s
-    )
-    assert (
-        abs(to_cartesian_differential.v_z - cartesian_differential.v_z)
-        <= (1e-5) * u.km / u.s
-    )
-
-
-def assert_spherical_pos(spherical_differential, to_spherical_differential):
-    assert abs(to_spherical_differential.r - spherical_differential.r) <= (1e-5) * u.km
-    assert (
-        abs(to_spherical_differential.theta - spherical_differential.theta)
-        <= (1e-5) * u.rad
-    )
-    assert (
-        abs(to_spherical_differential.phi - spherical_differential.phi)
-        <= (1e-5) * u.rad
-    )
-
-
-def assert_spherical_differential(spherical_differential, to_spherical_differential):
-    assert (
-        abs(to_spherical_differential.v_r - spherical_differential.v_r)
-        <= (1e-5) * u.km / u.s
-    )
-    assert (
-        abs(to_spherical_differential.v_t - spherical_differential.v_t)
-        <= (1e-5) * u.rad / u.s
-    )
-    assert (
-        abs(to_spherical_differential.v_p - spherical_differential.v_p)
-        <= (1e-5) * u.rad / u.s
-    )
-
-
-def assert_boyerlindquist_pos(bl_differential, to_bl_differential):
-    assert abs(to_bl_differential.r - bl_differential.r) <= (1e-5) * u.km
-    assert abs(to_bl_differential.theta - bl_differential.theta) <= (1e-5) * u.rad
-    assert abs(to_bl_differential.phi - bl_differential.phi) <= (1e-5) * u.rad
-
-
-def assert_bl_differential(bl_differential, to_bl_differential):
-
-    assert abs(to_bl_differential.v_r - bl_differential.v_r) <= (1e-5) * u.km / u.s
-    assert abs(to_bl_differential.v_t - bl_differential.v_t) <= (1e-5) * u.rad / u.s
-    assert abs(to_bl_differential.v_p - bl_differential.v_p) <= (1e-5) * u.rad / u.s
 
 
 def test_CartesianToSphericalDifferential(
     cartesian_differential, spherical_differential
 ):
     to_spherical_differential = cartesian_differential.spherical_differential()
-    assert_spherical_pos(spherical_differential, to_spherical_differential)
-    assert_spherical_differential(spherical_differential, to_spherical_differential)
+    assert_allclose(
+        to_spherical_differential.si_values(),
+        spherical_differential.si_values(),
+        rtol=0.0,
+        atol=1e-6,
+    )
 
 
 def test_CartesianToBoyerLindquistDifferential(cartesian_differential, bl_differential):
-    bl_differential, a = bl_differential
-    to_bl_differential = cartesian_differential.bl_differential(a)
-    assert_boyerlindquist_pos(bl_differential, to_bl_differential)
-    assert_bl_differential(bl_differential, to_bl_differential)
+    to_bl_differential = cartesian_differential.bl_differential(bl_differential.a)
+    assert_allclose(
+        to_bl_differential.si_values(), bl_differential.si_values(), rtol=0.0, atol=1e-6
+    )
 
 
 def test_SphericalToCartesianDifferential(
     spherical_differential, cartesian_differential
 ):
     to_cartesian_differential = spherical_differential.cartesian_differential()
-    assert_cartesian_pos(cartesian_differential, to_cartesian_differential)
-    assert_cartesian_differential(cartesian_differential, to_cartesian_differential)
+    assert_allclose(
+        to_cartesian_differential.si_values(),
+        cartesian_differential.si_values(),
+        rtol=0.0,
+        atol=1e-6,
+    )
 
 
 def test_SphericalToBoyerLindquistDifferential(spherical_differential, bl_differential):
-    bl_differential, a = bl_differential
-    to_bl_differential = spherical_differential.bl_differential(a)
-    assert_boyerlindquist_pos(bl_differential, to_bl_differential)
-    assert_bl_differential(bl_differential, to_bl_differential)
+    to_bl_differential = spherical_differential.bl_differential(bl_differential.a)
+    assert_allclose(
+        to_bl_differential.si_values(), bl_differential.si_values(), rtol=0.0, atol=1e-6
+    )
 
 
 def test_BoyerLindquistToCartesianDifferential(bl_differential, cartesian_differential):
-    bl_differential, a = bl_differential
-    to_cartesian_differential = bl_differential.cartesian_differential(a)
-    assert_cartesian_pos(cartesian_differential, to_cartesian_differential)
-    assert_cartesian_differential(cartesian_differential, to_cartesian_differential)
+    to_cartesian_differential = bl_differential.cartesian_differential()
+    assert_allclose(
+        to_cartesian_differential.si_values(),
+        cartesian_differential.si_values(),
+        rtol=0.0,
+        atol=1e-6,
+    )
 
 
 def test_BoyerLindquistToSphericalDifferential(bl_differential, spherical_differential):
-    bl_differential, a = bl_differential
-    to_spherical_differential = bl_differential.spherical_differential(a)
-    assert_spherical_pos(spherical_differential, to_spherical_differential)
-    assert_spherical_differential(spherical_differential, to_spherical_differential)
+    to_spherical_differential = bl_differential.spherical_differential()
+    assert_allclose(
+        to_spherical_differential.si_values(),
+        spherical_differential.si_values(),
+        rtol=0.0,
+        atol=1e-6,
+    )
+
+
+# Tests for object.__repr__ and object.__str__
+
+
+def test_print_core_objects(
+    cartesian_differential, spherical_differential, bl_differential
+):
+    old_stdout = sys.stdout
+    # change stdout
+    result = StringIO()
+    sys.stdout = result
+
+    print(str(cartesian_differential))
+    assert "object at 0x" not in result.getvalue()
+
+    print(str(spherical_differential))
+    assert "object at 0x" not in result.getvalue()
+
+    print(str(bl_differential))
+    assert "object at 0x" not in result.getvalue()
+
+    # again switch to old stdout
+    sys.stdout = old_stdout

--- a/src/einsteinpy/tests/test_coordinates/test_velocity_transform.py
+++ b/src/einsteinpy/tests/test_coordinates/test_velocity_transform.py
@@ -46,6 +46,19 @@ def bl_differential():
     )
 
 
+@pytest.fixture()
+def bl_differential2():
+    return coordinates.BoyerLindquistDifferential(
+        4 * u.km,
+        2 * u.rad,
+        1 * u.rad,
+        -100 * u.m / u.s,
+        -1 * u.rad / u.s,
+        10 * u.deg / u.s,
+        100 * u.m,
+    )
+
+
 def test_CartesianToSphericalDifferential(
     cartesian_differential, spherical_differential
 ):
@@ -102,6 +115,20 @@ def test_BoyerLindquistToSphericalDifferential(bl_differential, spherical_differ
         rtol=0.0,
         atol=1e-6,
     )
+
+
+def test_cycle_BLSphericalDifferential(bl_differential2):
+    bl_diff = bl_differential2
+    sph_diff = bl_diff.spherical_differential()
+    bl_diff2 = sph_diff.bl_differential(bl_diff.a)
+    assert_allclose(bl_diff2.si_values(), bl_diff.si_values(), rtol=0.0, atol=1e-6)
+
+
+def test_cycle_BLCartesianDifferential(bl_differential2):
+    bl_diff = bl_differential2
+    cart_diff = bl_diff.cartesian_differential()
+    bl_diff2 = cart_diff.bl_differential(bl_diff.a)
+    assert_allclose(bl_diff2.si_values(), bl_diff.si_values(), rtol=0.0, atol=1e-6)
 
 
 # Tests for object.__repr__ and object.__str__


### PR DESCRIPTION
  - made parameter `a` a part of BL coordinate system.
  - added `__repr__` and `__str__` methods in classes. It now shows proper output when object is printed.
    ```
    >>> import astropy.units as u
    >>> from einsteinpy.coordinates import SphericalDifferential
    >>> s=SphericalDifferential(9*u.km, 200*u.deg, 0*u.deg, 1*u.km/u.min, 0*u.rad/u.s, 90*u.rad/u.s)
    >>> s
    Spherical r: 9.0 km, theta: 200.0 deg, phi: 0.0 deg
    vr: 1.0 km / min, vt: 0.0 rad / s, vp: 90.0 rad / s
    >>> print(s)
    Spherical r: 9.0 km, theta: 200.0 deg, phi: 0.0 deg
    vr: 1.0 km / min, vt: 0.0 rad / s, vp: 90.0 rad / s
    ```
  - added a function `si_values()` in each class which returns a numpy array containing the SI values(units are not needed as SI units are already known. This function would provide much ease when `metric` does it's transition to `coordinates` from `utils`)
  - updated tests!