### PR TITLE
Changed warning type

### DIFF
--- a/src/einsteinpy/utils/bl_coord_transforms.py
+++ b/src/einsteinpy/utils/bl_coord_transforms.py
@@ -4,7 +4,8 @@ import astropy.units as u
 import numpy as np
 
 warnings.warn(
-    "This module will be deprecated in EinsteinPy v0.3.0. Please switch to `einsteinpy.coordinates`."
+    "This module will be deprecated in EinsteinPy v0.3.0. Please switch to `einsteinpy.coordinates`.",
+    PendingDeprecationWarning,
 )
 
 

--- a/src/einsteinpy/utils/coord_transforms.py
+++ b/src/einsteinpy/utils/coord_transforms.py
@@ -4,7 +4,8 @@ import astropy.units as u
 import numpy as np
 
 warnings.warn(
-    "This module will be deprecated in EinsteinPy v0.3.0. Please switch to `einsteinpy.coordinates`."
+    "This module will be deprecated in EinsteinPy v0.3.0. Please switch to `einsteinpy.coordinates`.",
+    PendingDeprecationWarning,
 )
 
 


### PR DESCRIPTION
Fixes #200

Changed warning category from `UserWarning` (which was default warning) to `PendingDeprecationWarning` in files given below:-

`src/einsteinpy/utils/bl_coord_transforms.py`

`src/einsteinpy/utils/coord_transforms.py`