### PR TITLE
Fix isort issues

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+combine_as_imports=True
+line_length=88

--- a/src/einsteinpy/coordinates/__init__.py
+++ b/src/einsteinpy/coordinates/__init__.py
@@ -1,7 +1,6 @@
 from .core import BoyerLindquist, Cartesian, Spherical
-
-from .velocity import (  # isort:skip
+from .velocity import (
     BoyerLindquistDifferential,
     CartesianDifferential,
     SphericalDifferential,
-)  # isort:skip added because isort and black conflict on the above import, to be fixed later
+)

--- a/src/einsteinpy/metric/kerr.py
+++ b/src/einsteinpy/metric/kerr.py
@@ -6,8 +6,7 @@ import numpy as np
 from einsteinpy import constant
 from einsteinpy.integrators import RK45
 from einsteinpy.utils import *
-from einsteinpy.utils import kerr_utils
-from einsteinpy.utils import schwarzschild_radius as scr
+from einsteinpy.utils import kerr_utils, schwarzschild_radius as scr
 
 _G = constant.G.value
 _c = constant.c.value


### PR DESCRIPTION
<!-- Please fill below the issue number which this code fixes -->
Fixes #185 

<!-- Please tag any reviewer here -->

Run `isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 [ file.py ]`
when not in einsteinpy.