### PR TITLE
(Minor) Add an entry in .gitignore for Emacs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ pip-wheel-metadata
 # VS Code
 .vscode
 
+# Emacs
+TAGS
+
 # default pytest cache directory
 */.pytest_cache
 .pytest_cache/


### PR DESCRIPTION
<!-- Please fill below the issue number which this code fixes -->
I use Spacemacs as my editor and one of the features that it implements is called projectile. This plugin allows easier navigation through source code by creating a file called TAGS which maps function names to file/line number so that the definitions for functions can be jumped to instantly.

<!-- Please tag any reviewer here -->

