### PR TITLE
corrected a typo in index.ipynb

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -58,7 +58,7 @@
     "[![symbol](docs/source/examples/imgs/HermannWeyl.jpeg)](docs/source/examples/Weyl%20Tensor%20symbolic%20calculation.ipynb)\n",
     "<center><em>Hermann Weyl</em></center>\n",
     "\n",
-    "## [Eisntein Tensor calculations using Symbolic module](docs/source/examples/Einstein%20Tensor%20symbolic%20calculation.ipynb)\n",
+    "## [Einstein Tensor calculations using Symbolic module](docs/source/examples/Einstein%20Tensor%20symbolic%20calculation.ipynb)\n",
     "\n",
     "[![symbol](docs/source/examples/imgs/einstein.png)](docs/source/examples/Einstein%20Tensor%20symbolic%20calculation.ipynb)\n",
     "\n",


### PR DESCRIPTION
There was a typo in the title "Eisntein Tensor calculations using Symbolic module". Corrected Eisntein->Einstein.



