### PR TITLE
Adding new predefined metrics to symbolic module

### DIFF
--- a/docs/source/api/symbolic/predefined/full_list.rst
+++ b/docs/source/api/symbolic/predefined/full_list.rst
@@ -48,3 +48,38 @@ Davidson
 
 .. automodule:: einsteinpy.symbolic.predefined.davidson
     :members:
+
+
+Bessel Gravitational Wave
+-------------------------
+
+.. automodule:: einsteinpy.symbolic.predefined.bessel_gravitational_wave
+    :members:
+
+
+Barriola Vilekin
+----------------
+
+.. automodule:: einsteinpy.symbolic.predefined.barriola_vilenkin
+    :members:
+
+
+Bertotti Kasner
+---------------
+
+.. automodule:: einsteinpy.symbolic.predefined.bertotti_kasner
+    :members:
+
+
+Ernst
+-----
+
+.. automodule:: einsteinpy.symbolic.predefined.ernst
+    :members:
+
+
+Janis Newman Winicour
+---------------------
+
+.. automodule:: einsteinpy.symbolic.predefined.janis_newman_winicour
+    :members:

--- a/src/einsteinpy/symbolic/predefined/__init__.py
+++ b/src/einsteinpy/symbolic/predefined/__init__.py
@@ -1,7 +1,12 @@
+from .barriola_vilenkin import BarriolaVilekin
+from .bertotti_kasner import BertottiKasner
+from .bessel_gravitational_wave import BesselGravitationalWave
 from .cmetric import CMetric
 from .davidson import Davidson
 from .de_sitter import AntiDeSitter, AntiDeSitterStatic, DeSitter
+from .ernst import Ernst
 from .find import find
 from .godel import Godel
+from .janis_newman_winicour import JanisNewmanWinicour
 from .minkowski import Minkowski
 from .vacuum_solutions import Kerr, KerrNewman, Schwarzschild

--- a/src/einsteinpy/symbolic/predefined/barriola_vilenkin.py
+++ b/src/einsteinpy/symbolic/predefined/barriola_vilenkin.py
@@ -1,0 +1,28 @@
+from sympy import diag, sin, symbols
+
+from einsteinpy.symbolic import constants
+from einsteinpy.symbolic.metric import MetricTensor
+
+
+def BarriolaVilekin(c=constants.c, k=symbols("k")):
+    """
+    Barriola-Vilekin monopol metric 
+    Phys. Rev. Lett. 63, 341
+    Manuel Barriola and Alexander Vilenkin
+    Published 24 July 1989
+
+    Parameters
+    ----------
+    c : ~sympy.core.basic.Basic or int or float
+        Any value to assign to speed of light. Defaults to 'c'.
+    k : ~sympy.core.basic.Basic or int or float
+        The scaling factor responsible for the deficit/surplus angle
+        Defaults to ``k``.
+    """
+    coords = symbols("t r theta phi")
+    t, r, th, ph = coords
+    # define the metric
+    metric = diag(
+        -1, 1 / (c ** 2), ((k * r) ** 2) / (c ** 2), ((k * r * sin(th)) ** 2) / (c ** 2)
+    ).tolist()
+    return MetricTensor(metric, coords, "ll")

--- a/src/einsteinpy/symbolic/predefined/bertotti_kasner.py
+++ b/src/einsteinpy/symbolic/predefined/bertotti_kasner.py
@@ -1,0 +1,30 @@
+from sympy import diag, exp, sin, sqrt, symbols
+
+from einsteinpy.symbolic import constants
+from einsteinpy.symbolic.metric import MetricTensor
+
+
+def BertottiKasner(c=constants.c, k=symbols("k"), lambd=symbols("l")):
+    """
+    Birkhoff’s theorem with Λ-term and Bertotti-Kasner space
+    Phys. Lett. A, 245:363–365, 1998
+    W. Rindler
+
+    Parameters
+    ----------
+    c : ~sympy.core.basic.Basic or int or float
+        Any value to assign to speed of light. Defaults to 'c'.
+    lambd : ~sympy.core.basic.Basic or int or float
+        The cosmological constant, note it must be postive. 
+        Defaults to ``l``.
+    """
+    coords = symbols("t r theta phi")
+    t, r, th, ph = coords
+    # define the metric
+    metric = diag(
+        -1,
+        exp(2 * sqrt(lambd) * c * t) / (c ** 2),
+        1 / (lambd * (c ** 2)),
+        (sin(th) ** 2) / (lambd * (c ** 2)),
+    ).tolist()
+    return MetricTensor(metric, coords, "ll")

--- a/src/einsteinpy/symbolic/predefined/bessel_gravitational_wave.py
+++ b/src/einsteinpy/symbolic/predefined/bessel_gravitational_wave.py
@@ -1,0 +1,45 @@
+from sympy import Function, Symbol, besselj, cos, diag, exp, sin, sqrt, symbols
+
+from einsteinpy.symbolic import constants
+from einsteinpy.symbolic.metric import MetricTensor
+
+
+def BesselGravitationalWave(C=symbols("C")):
+    """
+    Exact gravitational wave solution without diffraction.
+    Class. Quantum Grav., 16:L75–78, 1999.
+    D. Kramer.
+
+    An exact solution describing an axisymmetric gravitational wave propagating in the
+    z-direction in closed form. This solution to Einstein’s vacuum field equations has the
+    remarkable property that the curvature invariants decrease monotonically with increasing radial
+    distance from the axis and vanish at infinity. The solution is regular at the symmetry axis.
+
+    Parameters
+    ----------
+    C : ~sympy.core.basic.Basic or int or float
+        Constant for Bessel metric, the choice of the constant is not really relavent for details see the paper. Defaults to 'C'.
+    """
+    coords = symbols("t rho phi z")
+    t, rho, ph, z = coords
+
+    # Useful helper functions, these wrap the Bessel functions that are used. C is some constant here
+    U = C * besselj(rho, 0) * cos(t)
+    K = (
+        (1 / 2)
+        * (C ** 2)
+        * rho
+        * (
+            (rho * ((besselj(rho, 0) ** 2) + (besselj(rho, 1) ** 2)))
+            - (2 * besselj(rho, 0) * besselj(rho, 1) * (cos(t) ** 2))
+        )
+    )
+
+    # define the metric
+    metric = diag(
+        -1 * exp(-2 * U) * exp(2 * K),
+        exp(-2 * U) * exp(2 * K),
+        exp(-2 * U) * (rho ** 2),
+        exp(2 * U),
+    ).tolist()
+    return MetricTensor(metric, coords, "ll")

--- a/src/einsteinpy/symbolic/predefined/ernst.py
+++ b/src/einsteinpy/symbolic/predefined/ernst.py
@@ -1,0 +1,34 @@
+from sympy import diag, exp, sin, sqrt, symbols
+
+from einsteinpy.symbolic import constants
+from einsteinpy.symbolic.metric import MetricTensor
+
+
+def Ernst(B=symbols("B"), M=symbols("M")):
+    """
+    Black holes in a magnetic universe.
+    J. Math. Phys., 17:54–56, 1976.
+    Frederick J. Ernst.
+
+    Parameters
+    ----------
+    M : ~sympy.core.basic.Basic or int or float
+        Mass of the black hole. Defaults to ``M``.
+    B : ~sympy.core.basic.Basic or int or float
+        The magnetic field strength
+        Defaults to ``B``.
+    """
+    coords = symbols("t r theta phi")
+    t, r, th, ph = coords
+    # Helper functions
+    lambd = 1 + ((B * r * sin(th)) ** 2)
+    w = 1 - ((2 * M) / r)
+
+    # define the metric
+    metric = diag(
+        -1 * (lambd ** 2) * w,
+        (lambd ** 2) / w,
+        ((r * lambd) ** 2),
+        (((r * sin(th)) / lambd) ** 2),
+    ).tolist()
+    return MetricTensor(metric, coords, "ll")

--- a/src/einsteinpy/symbolic/predefined/janis_newman_winicour.py
+++ b/src/einsteinpy/symbolic/predefined/janis_newman_winicour.py
@@ -1,0 +1,36 @@
+from sympy import diag, sin, symbols
+
+from einsteinpy.symbolic import constants
+from einsteinpy.symbolic.metric import MetricTensor
+
+
+def JanisNewmanWinicour(
+    c=constants.c, G=constants.G, gam=symbols("gam"), M=symbols("M")
+):
+    """ 
+    Reality of the Schwarzschild singularity.
+    Phys. Rev. Lett., 20:878–880, 1968.
+    A. I. Janis, E. T. Newman, and J. Winicour.
+
+    Parameters
+    ----------
+    M : ~sympy.core.basic.Basic or int or float
+        Mass parameter, this is used for defining the schwarzschild metric. Defaults to ``M``.
+    gam : ~sympy.core.basic.Basic or int or float
+        Parameter for scaling  Schwarzschild radius, for gamma=1 this will return the  Schwarzschild metric
+        Defaults to ``gam``.
+    """
+    coords = symbols("t r theta phi")
+    t, r, th, ph = coords
+    # Helper functions
+    r_s = (2 * G * M) / (c ** 2)
+    alpha = 1 - (r_s / (gam * r))
+
+    # define the metric
+    metric = diag(
+        -1 * (alpha ** gam),
+        (alpha ** -gam) / (c ** 2),
+        (r ** 2) * (alpha ** (-gam + 1)),
+        (r ** 2) * (alpha ** (-gam + 1)) * (sin(th) ** 2),
+    ).tolist()
+    return MetricTensor(metric, coords, "ll")

--- a/src/einsteinpy/tests/test_symbolic/test_predefined/test_all.py
+++ b/src/einsteinpy/tests/test_symbolic/test_predefined/test_all.py
@@ -6,10 +6,15 @@ from einsteinpy.symbolic import MetricTensor, simplify_sympy_array
 from einsteinpy.symbolic.predefined import (
     AntiDeSitter,
     AntiDeSitterStatic,
+    BarriolaVilekin,
+    BertottiKasner,
+    BesselGravitationalWave,
     CMetric,
     Davidson,
     DeSitter,
+    Ernst,
     Godel,
+    JanisNewmanWinicour,
     Kerr,
     KerrNewman,
     Minkowski,
@@ -31,6 +36,11 @@ from einsteinpy.symbolic.predefined import (
         CMetric(),
         Davidson(),
         Godel(),
+        BesselGravitationalWave(),
+        BarriolaVilekin(),
+        BertottiKasner(),
+        Ernst(),
+        JanisNewmanWinicour(),
     ],
 )
 def test_all_predefined_metrics(metric_instance):


### PR DESCRIPTION
Fixes #309
I've added in the barriola vilekin metric, berttoti kasner metric, and bessel gravitational wave metrics to the symbolic module. I should be adding a few more soon as well.


@ritzvik 

