### PR TITLE
Reissner-Nordstorm metric to symbolic module

### DIFF
--- a/src/einsteinpy/symbolic/christoffel.py
+++ b/src/einsteinpy/symbolic/christoffel.py
@@ -12,7 +12,7 @@ class ChristoffelSymbols(BaseRelativityTensor):
     """
 
     def __init__(
-        self, arr, syms, config="ull", parent_metric=None, name="ChristoffelSymbols",
+        self, arr, syms, config="ull", parent_metric=None, name="ChristoffelSymbols"
     ):
         """
         Constructor and Initializer

--- a/src/einsteinpy/symbolic/predefined/__init__.py
+++ b/src/einsteinpy/symbolic/predefined/__init__.py
@@ -9,4 +9,4 @@ from .find import find
 from .godel import Godel
 from .janis_newman_winicour import JanisNewmanWinicour
 from .minkowski import Minkowski, MinkowskiCartesian, MinkowskiPolar
-from .vacuum_solutions import Kerr, KerrNewman, Schwarzschild
+from .vacuum_solutions import Kerr, KerrNewman, ReissnerNordstorm, Schwarzschild

--- a/src/einsteinpy/symbolic/predefined/vacuum_solutions.py
+++ b/src/einsteinpy/symbolic/predefined/vacuum_solutions.py
@@ -15,9 +15,9 @@ def Schwarzschild(c=constants.c, sch=symbols("r_s")):
     c : ~sympy.core.basic.Basic or int or float
         Any value to assign to speed of light. Defaults to ``c``.
     sch : ~sympy.core.basic.Basic or int or float
-        Any value to assign to Schwarzschild Radius of the central object. 
+        Any value to assign to Schwarzschild Radius of the central object.
         Defaults to ``r_s``.
-    
+
     """
     coords = symbols("t r theta phi")
     t, r, theta, phi = coords
@@ -37,7 +37,7 @@ def Kerr(c=constants.c, sch=symbols("r_s"), a=symbols("a")):
     c : ~sympy.core.basic.Basic or int or float
         Any value to assign to speed of light. Defaults to ``c``.
     sch : ~sympy.core.basic.Basic or int or float
-        Any value to assign to Schwarzschild Radius of the central object. 
+        Any value to assign to Schwarzschild Radius of the central object.
         Defaults to ``r_s``.
     a : ~sympy.core.basic.Basic or int or float
         Spin factor of the heavy body. Usually, given by ``J/(Mc)``,
@@ -85,14 +85,14 @@ def KerrNewman(
     eps_0 : ~sympy.core.basic.Basic or int or float
         Any value to assign to the electric constant or permittivity of free space. Defaults to ``eps_0``.
     sch : ~sympy.core.basic.Basic or int or float
-        Any value to assign to Schwarzschild Radius of the central object. 
+        Any value to assign to Schwarzschild Radius of the central object.
         Defaults to ``r_s``.
     a : ~sympy.core.basic.Basic or int or float
         Spin factor of the heavy body. Usually, given by ``J/(Mc)``,
         where ``J`` is the angular momentum.
         Defaults to ``a``.
     Q:  ~sympy.core.basic.Basic or int or float
-        Any value to assign to eletric charge of the central object. 
+        Any value to assign to eletric charge of the central object.
         Defaults to ``Q``.
 
     """
@@ -115,3 +115,45 @@ def KerrNewman(
     ).tolist()
     metric[0][3] = metric[3][0] = sch * r * a * (sin(theta) ** 2) / (Sigma * c)
     return MetricTensor(metric, coords, "ll", name="KerrNewmanMetric")
+
+
+def ReissnerNordstorm(
+    c=constants.c,
+    G=constants.G,
+    eps_0=constants.eps_0,
+    sch=symbols("r_s"),
+    Q=symbols("Q"),
+):
+    """"
+    The Reissner–Nordström metric in spherical coordinates
+
+    A static solution to the Einstein–Maxwell field equations,
+    which corresponds to the gravitational field of a charged,
+    non-rotating, spherically symmetric body of mass M.
+
+    Parameters
+    ----------
+    c : ~sympy.core.basic.Basic or int or float
+        Any value to assign to speed of light. Defaults to ``c``.
+    G : ~sympy.core.basic.Basic or int or float
+        Any value to assign to the Newton's (or gravitational) constant. Defaults to ``G``.
+    eps_0 : ~sympy.core.basic.Basic or int or float
+        Any value to assign to the electric constant or permittivity of free space. Defaults to ``eps_0``.
+    sch : ~sympy.core.basic.Basic or int or float
+        Any value to assign to Schwarzschild Radius of the central object.
+        Defaults to ``r_s``.
+    Q:  ~sympy.core.basic.Basic or int or float
+        Any value to assign to eletric charge of the central object.
+        Defaults to ``Q``.
+
+    """
+    coords = symbols("t r theta phi")
+    t, r, theta, phi = coords
+    rQsq = ((Q ** 2) * G) / (4 * pi * eps_0 * (c ** 4))
+    Arn = 1 - sch / r + rQsq / r ** 2
+    c2 = c ** 2
+
+    metric = diag(
+        (Arn), -(1 / Arn) / c2, -(r ** 2) / c2, -(r ** 2) * sin(theta) ** 2 / c2,
+    ).tolist()
+    return MetricTensor(metric, coords, "ll", name="ReissnerNordstormMetric")

--- a/src/einsteinpy/symbolic/predefined/vacuum_solutions.py
+++ b/src/einsteinpy/symbolic/predefined/vacuum_solutions.py
@@ -23,7 +23,7 @@ def Schwarzschild(c=constants.c, sch=symbols("r_s")):
     t, r, theta, phi = coords
     val1, c2 = 1 - sch / r, c ** 2
     metric = diag(
-        val1, -1 / (val1 * c2), -1 * (r ** 2) / c2, -1 * ((r * sin(theta)) ** 2) / c2
+        val1, -1 / (val1 * c2), -(r ** 2) / c2, -((r * sin(theta)) ** 2) / c2
     ).tolist()
     return MetricTensor(metric, coords, "ll", name="SchwarzschildMetric")
 
@@ -104,16 +104,14 @@ def KerrNewman(
     c2 = c ** 2
 
     metric = diag(
-        1 - (sch * r / Sigma),
+        1 + ((rQsq - sch * r) / Sigma),
         -Sigma / (Delta * c2),
         -Sigma / c2,
-        -(
-            (r ** 2 + a ** 2 + (sch * r * (a ** 2) * (sin(theta) ** 2) / Sigma))
-            * (sin(theta) ** 2)
-        )
-        / c2,
+        (Delta * a ** 2 * sin(theta) ** 2 - (r ** 2 + a ** 2) ** 2)
+        * sin(theta) ** 2
+        / (Sigma * c2),
     ).tolist()
-    metric[0][3] = metric[3][0] = sch * r * a * (sin(theta) ** 2) / (Sigma * c)
+    metric[0][3] = metric[3][0] = (sch * r - rQsq) * a * (sin(theta) ** 2) / (Sigma * c)
     return MetricTensor(metric, coords, "ll", name="KerrNewmanMetric")
 
 
@@ -126,7 +124,6 @@ def ReissnerNordstorm(
 ):
     """"
     The Reissner–Nordström metric in spherical coordinates
-
     A static solution to the Einstein–Maxwell field equations,
     which corresponds to the gravitational field of a charged,
     non-rotating, spherically symmetric body of mass M.
@@ -154,6 +151,6 @@ def ReissnerNordstorm(
     c2 = c ** 2
 
     metric = diag(
-        (Arn), -(1 / Arn) / c2, -(r ** 2) / c2, -(r ** 2) * sin(theta) ** 2 / c2,
+        Arn, -1 / (Arn * c2), -(r ** 2) / c2, -(r ** 2) * sin(theta) ** 2 / c2
     ).tolist()
     return MetricTensor(metric, coords, "ll", name="ReissnerNordstormMetric")

--- a/src/einsteinpy/tests/test_symbolic/test_predefined/test_all.py
+++ b/src/einsteinpy/tests/test_symbolic/test_predefined/test_all.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
-from sympy import Array
+from sympy import Array, diag, pi, symbols
 
-from einsteinpy.symbolic import MetricTensor, simplify_sympy_array
+from einsteinpy.symbolic import MetricTensor, constants, simplify_sympy_array
 from einsteinpy.symbolic.predefined import (
     AntiDeSitter,
     AntiDeSitterStatic,
@@ -20,6 +20,7 @@ from einsteinpy.symbolic.predefined import (
     Minkowski,
     MinkowskiCartesian,
     MinkowskiPolar,
+    ReissnerNordstorm,
     Schwarzschild,
 )
 
@@ -45,6 +46,7 @@ from einsteinpy.symbolic.predefined import (
         BertottiKasner(),
         Ernst(),
         JanisNewmanWinicour(),
+        ReissnerNordstorm(),
     ],
 )
 def test_all_predefined_metrics(metric_instance):
@@ -61,6 +63,27 @@ def test_all_predefined_metrics(metric_instance):
 def test_check_two_metrics_are_equal(m1, m2):
     zero_arr = Array(np.zeros(shape=m1.tensor().shape, dtype=int))
     assert simplify_sympy_array(m1.tensor() - m2.tensor()) == zero_arr
+
+
+@pytest.mark.parametrize(
+    "m1, m2",
+    [
+        (
+            ReissnerNordstorm(),
+            KerrNewman(a=0),
+        ),  # Reissner-Nordstorm is a special case of Kerr-Newman
+    ],
+)
+def test_check_ReissnerNordstorm(m1, m2):
+    coords = symbols("t r theta phi")
+    t, r, theta, phi = coords
+    c, G, eps_0, Q = constants.c, constants.G, constants.eps_0, symbols("Q")
+    rQsq = (Q ** 2) * G / (4 * pi * eps_0 * (c ** 4))
+    metric = diag(rQsq / r ** 2, 0, 0, 0).tolist()
+    test_arr = MetricTensor(metric, coords, "ll", name="test_metric")
+    assert simplify_sympy_array(m1.tensor() - m2.tensor()) == simplify_sympy_array(
+        test_arr.tensor()
+    )
 
 
 def test_Minkowski_equality():

--- a/src/einsteinpy/tests/test_symbolic/test_predefined/test_all.py
+++ b/src/einsteinpy/tests/test_symbolic/test_predefined/test_all.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
-from sympy import Array, diag, pi, symbols
+from sympy import Array
 
-from einsteinpy.symbolic import MetricTensor, constants, simplify_sympy_array
+from einsteinpy.symbolic import MetricTensor, simplify_sympy_array
 from einsteinpy.symbolic.predefined import (
     AntiDeSitter,
     AntiDeSitterStatic,
@@ -58,32 +58,19 @@ def test_all_predefined_metrics(metric_instance):
     [
         (Schwarzschild(), Kerr(a=0)),  # Schwarzschild is a special case of Kerr
         (Kerr(), KerrNewman(Q=0)),  # Kerr is a special case of Kerr-Newman
+        (
+            ReissnerNordstorm(),
+            KerrNewman(a=0),
+        ),  # Reissner-Nordstorm is a special case of Kerr-Newman
+        (
+            Schwarzschild(),
+            ReissnerNordstorm(Q=0),
+        ),  # Schwarzschild is a special case of Reissner-Nordstorm
     ],
 )
 def test_check_two_metrics_are_equal(m1, m2):
     zero_arr = Array(np.zeros(shape=m1.tensor().shape, dtype=int))
     assert simplify_sympy_array(m1.tensor() - m2.tensor()) == zero_arr
-
-
-@pytest.mark.parametrize(
-    "m1, m2",
-    [
-        (
-            ReissnerNordstorm(),
-            KerrNewman(a=0),
-        ),  # Reissner-Nordstorm is a special case of Kerr-Newman
-    ],
-)
-def test_check_ReissnerNordstorm(m1, m2):
-    coords = symbols("t r theta phi")
-    t, r, theta, phi = coords
-    c, G, eps_0, Q = constants.c, constants.G, constants.eps_0, symbols("Q")
-    rQsq = (Q ** 2) * G / (4 * pi * eps_0 * (c ** 4))
-    metric = diag(rQsq / r ** 2, 0, 0, 0).tolist()
-    test_arr = MetricTensor(metric, coords, "ll", name="test_metric")
-    assert simplify_sympy_array(m1.tensor() - m2.tensor()) == simplify_sympy_array(
-        test_arr.tensor()
-    )
 
 
 def test_Minkowski_equality():


### PR DESCRIPTION
Added the Reissner-Nordstorm metric to vacuum_solutions.py and added a new test function in the test_all.py for the same.
Fixes #309 

@ritzvik 
@shreyasbapat 


Sorry about a new PR. I was trying to squash my commits in the old PR and ended up breaking everything. I had to delete my repository and refork this to my account. Starting afresh again :(
