### PR TITLE
Fix typo in kerr.py

### DIFF
--- a/src/einsteinpy/metric/kerr.py
+++ b/src/einsteinpy/metric/kerr.py
@@ -14,7 +14,7 @@ _c = constant.c.value
 
 class Kerr:
     """
-    Class for defining Kerr Goemetry Methdos
+    Class for defining Kerr Geometry Methods
     """
 
     @u.quantity_input(time=u.s, M=u.kg)


### PR DESCRIPTION
Fixed a typo discovered while researching Null Geodesics project

If this is the kind of thing that doesn't deserve its own pull request just let me know
