### PR TITLE
Remove functions deprecated in v0.3.0

### DIFF
--- a/src/einsteinpy/hypersurface/schwarzschildembedding.py
+++ b/src/einsteinpy/hypersurface/schwarzschildembedding.py
@@ -140,13 +140,13 @@ class SchwarzschildEmbedding:
         ----------
         alpha : float
             scaling factor to obtain the step size for incrementing r
-        
+
         Returns
         -------
         tuple
             (~numpy.array of X, ~numpy.array of Y, ~numpy.array of Z) values in cartesian coordinates
             obtained after applying solid of revolution
-        
+
         """
         r_initial = self.r_init.value
         r_step = self.M.value / alpha
@@ -175,15 +175,3 @@ class SchwarzschildEmbedding:
 
         Z.reshape((X.shape[0], X.shape[1]))
         return X, Y, Z
-
-    def plot_hypersurface(self, plot_type="wireframe", alpha=100):
-        msg = "This method is deprecated from 0.2.2 . To plot the  \
-               hypersurface, use ~einsteinpy.plotting.HypersurfacePlotter \
-               Please have a look at the documentation for more details"
-        raise warnings.warn(msg, DeprecationWarning)
-
-    def show(self):
-        msg = "This method will be deprecated from 0.2.2 . To plot the  \
-               hypersurface, use ~einsteinpy.plotting.HypersurfacePlotter \
-               Please have a look at the documentation for more details"
-        raise warnings.warn(msg, DeprecationWarning)


### PR DESCRIPTION
Fixes #483

Review by @ritzvik requested

### Changes
This PR removes the deprecated `plot_hypersurface()` and `show()` methods of the `SchwarzschildEmbedding` class in `src/einsteinpy/hypersurface/schwarzschildembedding.py`.

### Docs
1. This example in the docs may need to be deprecated, versioned or removed:
https://docs.einsteinpy.org/en/stable/examples/Plotting_spacial_hypersurface_embedding_for_schwarzschild_spacetime.html

2. I checked the Sphinx source files in `docs/source/api/hypersurface/` and neither file therein needed any changes as a result of this PR.

### Tests
- I ran the test suite with `python -c "import einsteinpy.testing; einsteinpy.testing.test()"`
- The test output is `231 passed, 6 xfailed in 170.59s (0:02:50)` for both the `master` branch I forked and my feature branch.
