### PR TITLE
dividing jupyter notebooks wrt modules used

### DIFF
--- a/docs/source/jupyter.rst
+++ b/docs/source/jupyter.rst
@@ -1,20 +1,42 @@
 Jupyter notebooks
 =================
+   
+.. toctree::
+   :maxdepth: 1
+   :caption: hypersurface
+   
+   /examples/Plotting spacial hypersurface embedding for schwarzschild spacetime.ipynb
 
 .. toctree::
    :maxdepth: 1
-
-   /examples/Visualizing advance of perihelion of a test particle in Schwarzschild space-time.ipynb
-   /examples/Animations in EinsteinPy.ipynb
-   /examples/Symbolically Understanding Christoffel Symbol and Riemann Curvature Tensor using EinsteinPy.ipynb
-   /examples/Playing with Contravariant and Covariant Indices in Tensors(Symbolic).ipynb
-   /examples/Ricci Tensor and Scalar Curvature symbolic calculation.ipynb
-   /examples/Analysing Earth using EinsteinPy!.ipynb
-   /examples/Visualizing frame dragging in Kerr spacetime.ipynb
+   :caption: rays
+   
+   /examples/Shadow cast by an thin emission disk around a black hole.ipynb
+   
+.. toctree::
+   :maxdepth: 1
+   :caption: utils
+   
    /examples/Visualizing event horizon and ergosphere of Kerr black hole.ipynb
-   /examples/Plotting spacial hypersurface embedding for schwarzschild spacetime.ipynb
-   /examples/Weyl Tensor symbolic calculation.ipynb
+
+.. toctree::
+   :maxdepth: 1
+   :caption: metric, bodies, geodesic, coordinates
+   
+   /examples/Visualizing frame dragging in Kerr spacetime.ipynb
+   /examples/Analysing Earth using EinsteinPy!.ipynb
+   /examples/Animations in EinsteinPy.ipynb
+   /examples/Visualizing advance of perihelion of a test particle in Schwarzschild space-time.ipynb
+   
+.. toctree::
+   :maxdepth: 1
+   :caption: symbolic
+   
    /examples/Einstein Tensor symbolic calculation.ipynb
    /examples/Lambdify symbolic calculation.ipynb
+   /examples/Playing with Contravariant and Covariant Indices in Tensors(Symbolic).ipynb
    /examples/Predefined Metrics in Symbolic Module.ipynb
-   /examples/Shadow cast by an thin emission disk around a black hole.ipynb
+   /examples/Ricci Tensor and Scalar Curvature symbolic calculation.ipynb
+   /examples/Symbolically Understanding Christoffel Symbol and Riemann Curvature Tensor using EinsteinPy.ipynb
+   /examples/Weyl Tensor symbolic calculation.ipynb
+   


### PR DESCRIPTION
The index of jupyter notebook examples have been arranged according to the modules used in each of them. Most of the codes require multiple modules and thus I have used a combination of the module names to structure the index.

Fixes #469

@ritzvik

