### PR TITLE
Addresses #541 Jupyter Notebook links

### DIFF
--- a/docs/source/jupyter.rst
+++ b/docs/source/jupyter.rst
@@ -6,6 +6,10 @@ Jupyter notebooks
    :caption: hypersurface
    
    /examples/Plotting spacial hypersurface embedding for schwarzschild spacetime.ipynb
+   :target: https://en.wikipedia.org/wiki/Hypersurface
+   :alt: Spacial Hypersurface
+   :target: https://www.sciencedirect.com/science/article/pii/S0926224511000817
+   :alt: Schwarzschild Spacetime
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
<!-- Please fill below the issue number which this code fixes -->
Fixes #<Put_Issue_Number_Here>
[Issue 541 - Refine Jupyter Notebooks Page in Docs ](https://github.com/einsteinpy/einsteinpy/issues/541)

**Problem**

https://docs.einsteinpy.org/en/latest/jupyter.html

We need to have more descriptive headings in this. Maybe link those headings to some pages.

**Goal**

We should maybe make it more descriptive to use. A small summary or link to relevant article should be a good start
 **Solution**

1.Add description of what the code does for plotting spacial hypersurface embedding for schwarzschild spacetime.
2.Added a Wikipedia page for Schwarzschild Spacetime and article for spacial hypersurface.
**Steps to solve the problem**


**Changelog**
jupyter..rst

**Future enhancements**
1. Proceed with updation of all Jupyter Notebook links with descriptive articles/links
