### PR TITLE
__all__ added

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ CONTRIBUTORS
 - shreyasbapat
 - bibek22
 - JeS24
+- Qbiwan
 
 CHANGES
 - [#506]: Tests moved outside of the package. 
@@ -28,7 +29,9 @@ CHANGES
 - [#527]: Added support for Null Geodesics in Kerr & Schwarzschild Spacetimes
 - [#527]: Added new features to plotting.geodesic
 - [#527]: Dropped support for Python 3.6
-
+- [#547]: Fixed #516, Added __all__ across modules
+- [#547]: Fixed #552, Renamed missing attributes in einsteinpy.plotting.geodesic.static
+- [#547]: Increased test coverage for einsteinpy.ijit
 
 0.5.0
 -----

--- a/src/einsteinpy/bodies.py
+++ b/src/einsteinpy/bodies.py
@@ -19,19 +19,7 @@ from astropy import units as u
 
 from einsteinpy import constant
 
-__all__ = ["Body",
-           "_Sun",
-           "_Earth",
-           "_Moon",
-           "_Mercury",
-           "_Venus",
-           "_Mars",
-           "_Jupiter",
-           "_Saturn",
-           "_Uranus",
-           "_Neptune",
-           "_Pluto",
-           ]
+__all__ = ["Body"]
 
 
 class Body:

--- a/src/einsteinpy/bodies.py
+++ b/src/einsteinpy/bodies.py
@@ -19,7 +19,7 @@ from astropy import units as u
 
 from einsteinpy import constant
 
-__all__ = ["Body", 
+__all__ = ["Body",
            "_Sun",
            "_Earth",
            "_Moon",

--- a/src/einsteinpy/bodies.py
+++ b/src/einsteinpy/bodies.py
@@ -19,6 +19,20 @@ from astropy import units as u
 
 from einsteinpy import constant
 
+__all__ = ["Body", 
+           "_Sun",
+           "_Earth",
+           "_Moon",
+           "_Mercury",
+           "_Venus",
+           "_Mars",
+           "_Jupiter",
+           "_Saturn",
+           "_Uranus",
+           "_Neptune",
+           "_Pluto",
+           ]
+
 
 class Body:
     """

--- a/src/einsteinpy/constant.py
+++ b/src/einsteinpy/constant.py
@@ -1,6 +1,10 @@
 import numpy as np
 from astropy import constants, units as u
 
+__all__ = ["c", "G", "eps0", "coulombs_const",
+           "Cosmo_Const_base", "Cosmo_Const",
+           "Solar_Mass", "R_sun"]
+
 c = constants.c
 G = constants.G
 eps0 = constants.eps0

--- a/src/einsteinpy/constant.py
+++ b/src/einsteinpy/constant.py
@@ -1,9 +1,15 @@
 import numpy as np
 from astropy import constants, units as u
 
-__all__ = ["c", "G", "eps0", "coulombs_const",
-           "Cosmo_Const_base", "Cosmo_Const",
-           "Solar_Mass", "R_sun"]
+__all__ = [
+    "c",
+    "G",
+    "eps0",
+    "coulombs_const",
+    "Cosmo_Const",
+    "Solar_Mass",
+    "R_sun",
+]
 
 c = constants.c
 G = constants.G

--- a/src/einsteinpy/coordinates/__init__.py
+++ b/src/einsteinpy/coordinates/__init__.py
@@ -9,3 +9,14 @@ from .differential import (
     CartesianDifferential,
     SphericalDifferential,
 )
+
+__all__ = ["BoyerLindquistConversion",
+           "CartesianConversion",
+           "SphericalConversion",
+           "BoyerLindquist",
+           "Cartesian",
+           "Spherical",
+           "BoyerLindquistDifferential",
+           "CartesianDifferential",
+           "SphericalDifferential",
+           ]

--- a/src/einsteinpy/coordinates/__init__.py
+++ b/src/einsteinpy/coordinates/__init__.py
@@ -10,13 +10,14 @@ from .differential import (
     SphericalDifferential,
 )
 
-__all__ = ["BoyerLindquistConversion",
-           "CartesianConversion",
-           "SphericalConversion",
-           "BoyerLindquist",
-           "Cartesian",
-           "Spherical",
-           "BoyerLindquistDifferential",
-           "CartesianDifferential",
-           "SphericalDifferential",
-           ]
+__all__ = [
+    "BoyerLindquistConversion",
+    "CartesianConversion",
+    "SphericalConversion",
+    "BoyerLindquist",
+    "Cartesian",
+    "Spherical",
+    "BoyerLindquistDifferential",
+    "CartesianDifferential",
+    "SphericalDifferential",
+]

--- a/src/einsteinpy/examples.py
+++ b/src/einsteinpy/examples.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from einsteinpy.geodesic import Timelike
 
+__all__ = ["precession"]
 
 def precession():
     """

--- a/src/einsteinpy/examples.py
+++ b/src/einsteinpy/examples.py
@@ -4,6 +4,7 @@ from einsteinpy.geodesic import Timelike
 
 __all__ = ["precession"]
 
+
 def precession():
     """
     An example to showcase the usage of the various modules in ``einsteinpy``.

--- a/src/einsteinpy/geodesic/__init__.py
+++ b/src/einsteinpy/geodesic/__init__.py
@@ -1,3 +1,5 @@
 from .geodesic import Geodesic
 from .null import Nulllike
 from .timelike import Timelike
+
+__all__ = ["Geodesic", "Nulllike", "Timelike"]

--- a/src/einsteinpy/hypersurface/__init__.py
+++ b/src/einsteinpy/hypersurface/__init__.py
@@ -1,1 +1,3 @@
 from .schwarzschildembedding import SchwarzschildEmbedding
+
+__all__ = ["SchwarzschildEmbedding"]

--- a/src/einsteinpy/ijit.py
+++ b/src/einsteinpy/ijit.py
@@ -7,7 +7,7 @@ decorator instead.
 import inspect
 import warnings
 
-__all__ = ["ijit"]
+__all__ = ["jit"]
 
 
 def ijit(first=None, *args, **kwargs):
@@ -18,8 +18,8 @@ def ijit(first=None, *args, **kwargs):
 
     if inspect.isfunction(first):
         return first
-    else:
-        return _jit
+
+    return _jit
 
 
 try:

--- a/src/einsteinpy/ijit.py
+++ b/src/einsteinpy/ijit.py
@@ -7,6 +7,8 @@ decorator instead.
 import inspect
 import warnings
 
+__all__ = ["ijit"]
+
 
 def ijit(first=None, *args, **kwargs):
     """Identity JIT, returns unchanged function."""

--- a/src/einsteinpy/integrators/__init__.py
+++ b/src/einsteinpy/integrators/__init__.py
@@ -1,1 +1,3 @@
 from .runge_kutta import RK45, RK4naive
+
+__all__ = ["RK45", "RK4naive"]

--- a/src/einsteinpy/metric/__init__.py
+++ b/src/einsteinpy/metric/__init__.py
@@ -2,3 +2,5 @@ from .base_metric import BaseMetric
 from .kerr import Kerr
 from .kerrnewman import KerrNewman
 from .schwarzschild import Schwarzschild
+
+__all__ = ["BaseMetric", "Kerr", "KerrNewman", "Schwarzschild"]

--- a/src/einsteinpy/plotting/__init__.py
+++ b/src/einsteinpy/plotting/__init__.py
@@ -4,3 +4,11 @@ from einsteinpy.plotting.geodesic.interactive import InteractiveGeodesicPlotter
 from einsteinpy.plotting.geodesic.static import StaticGeodesicPlotter
 from einsteinpy.plotting.hypersurface.core import HypersurfacePlotter
 from einsteinpy.plotting.rays.shadow import ShadowPlotter
+
+__all__ = ["fractal",
+           "GeodesicPlotter",
+           "InteractiveGeodesicPlotter",
+           "StaticGeodesicPlotter",
+           "HypersurfacePlotter",
+           "ShadowPlotter"
+           ]

--- a/src/einsteinpy/plotting/__init__.py
+++ b/src/einsteinpy/plotting/__init__.py
@@ -5,10 +5,10 @@ from einsteinpy.plotting.geodesic.static import StaticGeodesicPlotter
 from einsteinpy.plotting.hypersurface.core import HypersurfacePlotter
 from einsteinpy.plotting.rays.shadow import ShadowPlotter
 
-__all__ = ["fractal",
-           "GeodesicPlotter",
-           "InteractiveGeodesicPlotter",
-           "StaticGeodesicPlotter",
-           "HypersurfacePlotter",
-           "ShadowPlotter"
-           ]
+__all__ = [
+    "GeodesicPlotter",
+    "InteractiveGeodesicPlotter",
+    "StaticGeodesicPlotter",
+    "HypersurfacePlotter",
+    "ShadowPlotter",
+]

--- a/src/einsteinpy/plotting/geodesic/static.py
+++ b/src/einsteinpy/plotting/geodesic/static.py
@@ -87,8 +87,8 @@ class StaticGeodesicPlotter:
             label="BH Event Horizon (Outer)",
         )
 
-        surface1._facecolors2d = surface1._facecolors3d
-        surface1._edgecolors2d = surface1._edgecolors3d
+        surface1._facecolors2d = surface1._facecolor3d
+        surface1._edgecolors2d = surface1._edgecolor3d
 
         # Outer Ergosphere
         if self.draw_ergosphere:
@@ -110,8 +110,8 @@ class StaticGeodesicPlotter:
                 label="BH Ergosphere (Outer)",
             )
 
-            surface2._facecolors2d = surface2._facecolors3d
-            surface2._edgecolors2d = surface2._edgecolors3d
+            surface2._facecolors2d = surface2._facecolor3d
+            surface2._edgecolors2d = surface2._edgecolor3d
 
     def _draw_bh_2D(self, a, figsize=(6, 6)):
         """

--- a/src/einsteinpy/rays/__init__.py
+++ b/src/einsteinpy/rays/__init__.py
@@ -1,1 +1,3 @@
 from .shadow import Shadow
+
+__all__ = ["ShadowPlotter"]

--- a/src/einsteinpy/rays/__init__.py
+++ b/src/einsteinpy/rays/__init__.py
@@ -1,3 +1,3 @@
 from .shadow import Shadow
 
-__all__ = ["ShadowPlotter"]
+__all__ = ["Shadow"]

--- a/src/einsteinpy/symbolic/__init__.py
+++ b/src/einsteinpy/symbolic/__init__.py
@@ -3,14 +3,6 @@ from .constants import SymbolicConstant, get_constant
 from .einstein import EinsteinTensor
 from .helpers import TransformationMatrix, simplify_sympy_array
 from .metric import MetricTensor
-from .ricci import RicciScalar, RicciTensor
-from .riemann import RiemannCurvatureTensor
-from .schouten import SchoutenTensor
-from .stress_energy_momentum import StressEnergyMomentumTensor
-from .tensor import BaseRelativityTensor, Tensor
-from .vector import GenericVector
-from .weyl import WeylTensor
-
 from .predefined.alcubierre_warp import AlcubierreWarp
 from .predefined.barriola_vilenkin import BarriolaVilekin
 from .predefined.bertotti_kasner import BertottiKasner
@@ -23,43 +15,55 @@ from .predefined.find import find
 from .predefined.godel import Godel
 from .predefined.janis_newman_winicour import JanisNewmanWinicour
 from .predefined.minkowski import Minkowski, MinkowskiCartesian, MinkowskiPolar
-from .predefined.vacuum_solutions import Kerr, KerrNewman, ReissnerNordstorm, Schwarzschild
+from .predefined.vacuum_solutions import (
+    Kerr,
+    KerrNewman,
+    ReissnerNordstorm,
+    Schwarzschild,
+)
+from .ricci import RicciScalar, RicciTensor
+from .riemann import RiemannCurvatureTensor
+from .schouten import SchoutenTensor
+from .stress_energy_momentum import StressEnergyMomentumTensor
+from .tensor import BaseRelativityTensor, Tensor
+from .vector import GenericVector
+from .weyl import WeylTensor
 
-
-__all__ = ["ChristoffelSymbols",
-           "SymbolicConstant",
-           "get_constant",
-           "EinsteinTensor",
-           "TransformationMatrix",
-           "simplify_sympy_array",
-           "MetricTensor",
-           "RicciScalar",
-           "RicciTensor",
-           "RiemannCurvatureTensor",
-           "SchoutenTensor",
-           "StressEnergyMomentumTensor",
-           "BaseRelativityTensor",
-           "Tensor",
-           "GenericVector",
-           "WeylTensor",
-           "AlcubierreWarp",
-           "BarriolaVilekin",
-           "BertottiKasner",
-           "BesselGravitationalWave",
-           "CMetric",
-           "Davidson",
-           "AntiDeSitter",
-           "AntiDeSitterStatic",
-           "DeSitter",
-           "Ernst",
-           "find",
-           "Godel",
-           "JanisNewmanWinicour",
-           "Minkowski",
-           "MinkowskiCartesian",
-           "MinkowskiPolar",
-           "Kerr",
-           "KerrNewman",
-           "ReissnerNordstorm",
-           "Schwarzschild"
-           ]
+__all__ = [
+    "ChristoffelSymbols",
+    "SymbolicConstant",
+    "get_constant",
+    "EinsteinTensor",
+    "TransformationMatrix",
+    "simplify_sympy_array",
+    "MetricTensor",
+    "RicciScalar",
+    "RicciTensor",
+    "RiemannCurvatureTensor",
+    "SchoutenTensor",
+    "StressEnergyMomentumTensor",
+    "BaseRelativityTensor",
+    "Tensor",
+    "GenericVector",
+    "WeylTensor",
+    "AlcubierreWarp",
+    "BarriolaVilekin",
+    "BertottiKasner",
+    "BesselGravitationalWave",
+    "CMetric",
+    "Davidson",
+    "AntiDeSitter",
+    "AntiDeSitterStatic",
+    "DeSitter",
+    "Ernst",
+    "find",
+    "Godel",
+    "JanisNewmanWinicour",
+    "Minkowski",
+    "MinkowskiCartesian",
+    "MinkowskiPolar",
+    "Kerr",
+    "KerrNewman",
+    "ReissnerNordstorm",
+    "Schwarzschild",
+]

--- a/src/einsteinpy/symbolic/__init__.py
+++ b/src/einsteinpy/symbolic/__init__.py
@@ -10,3 +10,56 @@ from .stress_energy_momentum import StressEnergyMomentumTensor
 from .tensor import BaseRelativityTensor, Tensor
 from .vector import GenericVector
 from .weyl import WeylTensor
+
+from .predefined.alcubierre_warp import AlcubierreWarp
+from .predefined.barriola_vilenkin import BarriolaVilekin
+from .predefined.bertotti_kasner import BertottiKasner
+from .predefined.bessel_gravitational_wave import BesselGravitationalWave
+from .predefined.cmetric import CMetric
+from .predefined.davidson import Davidson
+from .predefined.de_sitter import AntiDeSitter, AntiDeSitterStatic, DeSitter
+from .predefined.ernst import Ernst
+from .predefined.find import find
+from .predefined.godel import Godel
+from .predefined.janis_newman_winicour import JanisNewmanWinicour
+from .predefined.minkowski import Minkowski, MinkowskiCartesian, MinkowskiPolar
+from .predefined.vacuum_solutions import Kerr, KerrNewman, ReissnerNordstorm, Schwarzschild
+
+
+__all__ = ["ChristoffelSymbols",
+           "SymbolicConstant",
+           "get_constant",
+           "EinsteinTensor",
+           "TransformationMatrix",
+           "simplify_sympy_array",
+           "MetricTensor",
+           "RicciScalar",
+           "RicciTensor",
+           "RiemannCurvatureTensor",
+           "SchoutenTensor",
+           "StressEnergyMomentumTensor",
+           "BaseRelativityTensor",
+           "Tensor",
+           "GenericVector",
+           "WeylTensor",
+           "AlcubierreWarp",
+           "BarriolaVilekin",
+           "BertottiKasner",
+           "BesselGravitationalWave",
+           "CMetric",
+           "Davidson",
+           "AntiDeSitter",
+           "AntiDeSitterStatic",
+           "DeSitter",
+           "Ernst",
+           "find",
+           "Godel",
+           "JanisNewmanWinicour",
+           "Minkowski",
+           "MinkowskiCartesian",
+           "MinkowskiPolar",
+           "Kerr",
+           "KerrNewman",
+           "ReissnerNordstorm",
+           "Schwarzschild"
+           ]

--- a/src/einsteinpy/units.py
+++ b/src/einsteinpy/units.py
@@ -2,6 +2,7 @@ from astropy import units as u
 
 from einsteinpy.constant import G, c
 
+__all__ = ["primitive"]
 
 def primitive(*args):
     """

--- a/src/einsteinpy/units.py
+++ b/src/einsteinpy/units.py
@@ -4,6 +4,7 @@ from einsteinpy.constant import G, c
 
 __all__ = ["primitive"]
 
+
 def primitive(*args):
     """
     Strips out units and returns numpy.float64 values \

--- a/src/einsteinpy/utils/__init__.py
+++ b/src/einsteinpy/utils/__init__.py
@@ -1,1 +1,3 @@
 from .scalar_factor import scalar_factor, scalar_factor_derivative
+
+__all__ = ["scalar_factor", "scalar_factor_derivative"]

--- a/src/einsteinpy/utils/__init__.py
+++ b/src/einsteinpy/utils/__init__.py
@@ -1,3 +1,1 @@
 from .scalar_factor import scalar_factor, scalar_factor_derivative
-
-__all__ = ["scalar_factor", "scalar_factor_derivative"]

--- a/tests/test_ijit/test_ijit_without_numba.py
+++ b/tests/test_ijit/test_ijit_without_numba.py
@@ -8,7 +8,7 @@ import einsteinpy.ijit
 
 
 @mock.patch.dict(sys.modules, {"numba": None})
-def test():
+def test_warning_and_returntype():
     with warnings.catch_warnings(record=True) as w:
         custom_jit = reload(einsteinpy.ijit)
 
@@ -20,4 +20,14 @@ def test():
         assert isinstance(_simple_func, types.FunctionType)
 
 
-custom_jit = reload(einsteinpy.ijit)
+@mock.patch.dict(sys.modules, {"numba": None})
+def test_decorator():
+    custom_jit = reload(einsteinpy.ijit)
+
+    def _simple_func(a, b):
+        return a + b
+
+    res = custom_jit.jit()
+
+    assert res.__name__ == "_jit"
+    assert res(_simple_func).__name__ == "_simple_func"


### PR DESCRIPTION
<!-- Please fill below the issue number which this code fixes -->
Fixes #516

<!-- Please tag any reviewer here -->

@shreyasbapat 

In addition to adding `__add__` to **top-level files** in `einsteinpy`, I also added `__add__` to `__init__.py` for all **top-level folders** in `einsteinpy`.

1. adding `__add__` in folder could make the namespace cleaner when you run `from a import *`. 

In the example below, running the codes below only imports the necessary nine classes in folder **coordinates**, namely `BoyerLindquistConversion`,`CartesianConversion`, `SphericalConversion`, `BoyerLindquist`, `Cartesian`,`Spherical`, `BoyerLindquistDifferential`, `CartesianDifferential`, and `SphericalDifferential`.
```
(base):~/Downloads/einsteinpy-master/src$ python
>>> from einsteinpy.coordinates import *
>>> locals()
{'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <class '_frozen_importlib.BuiltinImporter'>, '__spec__': None, '__annotations__': {}, '__builtins__': <module 'builtins' (built-in)>, 
'BoyerLindquistConversion': <class 'einsteinpy.coordinates.conversion.BoyerLindquistConversion'>, 
'CartesianConversion': <class 'einsteinpy.coordinates.conversion.CartesianConversion'>,
'SphericalConversion': <class 'einsteinpy.coordinates.conversion.SphericalConversion'>,
'BoyerLindquist': <class 'einsteinpy.coordinates.core.BoyerLindquist'>, 
'Cartesian': <class 'einsteinpy.coordinates.core.Cartesian'>, 
'Spherical': <class 'einsteinpy.coordinates.core.Spherical'>, 
'BoyerLindquistDifferential': <class 'einsteinpy.coordinates.differential.BoyerLindquistDifferential'>, 
'CartesianDifferential': <class 'einsteinpy.coordinates.differential.CartesianDifferential'>, 
'SphericalDifferential': <class 'einsteinpy.coordinates.differential.SphericalDifferential'>}
>>> 
```
In contrast, running the same codes without `__add__`  added to `__init__.py`, as shown below, resulted in more than the nine necessary classes being imported into the namespace.

```
(base) :~/Downloads/einsteinpy-master/src$ python
>>> from einsteinpy.coordinates import *
>>> locals()
{'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <class '_frozen_importlib.BuiltinImporter'>, '__spec__': None, '__annotations__': {}, '__builtins__': <module 'builtins' (built-in)>, 
'utils': <module 'einsteinpy.coordinates.utils' from '/home/qbiwan/Downloads/einsteinpy-master/src/einsteinpy/coordinates/utils.py'>, 
'conversion': <module 'einsteinpy.coordinates.conversion' from '/home/qbiwan/Downloads/einsteinpy-master/src/einsteinpy/coordinates/conversion.py'>,
'BoyerLindquistConversion': <class 'einsteinpy.coordinates.conversion.BoyerLindquistConversion'>, 
'CartesianConversion': <class 'einsteinpy.coordinates.conversion.CartesianConversion'>, 
'SphericalConversion': <class 'einsteinpy.coordinates.conversion.SphericalConversion'>, 
'core': <module 'einsteinpy.coordinates.core' from '/home/qbiwan/Downloads/einsteinpy-master/src/einsteinpy/coordinates/core.py'>, 
'BoyerLindquist': <class 'einsteinpy.coordinates.core.BoyerLindquist'>, 
'Cartesian': <class 'einsteinpy.coordinates.core.Cartesian'>, 
'Spherical': <class 'einsteinpy.coordinates.core.Spherical'>, 
'differential': <module 'einsteinpy.coordinates.differential' from '/home/qbiwan/Downloads/einsteinpy-master/src/einsteinpy/coordinates/differential.py'>, 
'BoyerLindquistDifferential': <class 'einsteinpy.coordinates.differential.BoyerLindquistDifferential'>, 
'CartesianDifferential': <class 'einsteinpy.coordinates.differential.CartesianDifferential'>, 
'SphericalDifferential': <class 'einsteinpy.coordinates.differential.SphericalDifferential'>}
>>> 

```
Here are the unnecessary imports from the outputs above.
```
'utils': <module 'einsteinpy.coordinates.utils' from '/home/qbiwan/Downloads/einsteinpy-master/src/einsteinpy/coordinates/utils.py'>, 
'conversion': <module 'einsteinpy.coordinates.conversion' from '/home/qbiwan/Downloads/einsteinpy-master/src/einsteinpy/coordinates/conversion.py'>,
'core': <module 'einsteinpy.coordinates.core' from '/home/qbiwan/Downloads/einsteinpy-master/src/einsteinpy/coordinates/core.py'>
'differential': <module 'einsteinpy.coordinates.differential' from '/home/qbiwan/Downloads/einsteinpy-master/src/einsteinpy/coordinates/differential.py'>, 
```


2. I noticed that there were three names that clashed
 

- The same name **Kerr** is used in `einsteinpy/metric/kerr.py` and `einsteinpy/symbolic/predefined/vacuum_solutions.py`
- The same name **KerrNewman** is used in `einsteinpy/src/einsteinpy/metric/kerrnewman.py` and `einsteinpy/symbolic/predefined/vacuum_solutions.py`
- The same name **Schwarzschild** is used in `einsteinpy/symbolic/predefined/vacuum_solutions.py` and `einsteinpy/metric/schwarzschild.py`

Maybe some undesirable effects could occur if `from a import *` is used as often as you have described. A possible solution could be to rename the three above names in `symbolic/predefined/vacuum_solutions.py` to 
perhaps **KerrVaccumSolution**, **KerrNewmanVaccumSolution**, and **SchwarzschildVaccumSolution** 
or
 **KerrBoyerLindquist**, **KerrNewmanBoyerLindquist**, **SchwarzschildMetric**.

