### PR TITLE
CoordinateError class implemented

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ CONTRIBUTORS
 - bibek22
 - JeS24
 - Qbiwan
+- Aditya7799
 
 CHANGES
 - [#506]: Tests moved outside of the package. 
@@ -32,6 +33,7 @@ CHANGES
 - [#547]: Fixed #516, Added __all__ across modules
 - [#547]: Fixed #552, Renamed missing attributes in einsteinpy.plotting.geodesic.static
 - [#547]: Increased test coverage for einsteinpy.ijit
+- [#551]: Fixed #526, Exceptions module added, CoordinateError class implemented
 
 0.5.0
 -----

--- a/docs/source/api/utils/exceptions.rst
+++ b/docs/source/api/utils/exceptions.rst
@@ -1,0 +1,5 @@
+Exceptions module
+=================
+
+.. automodule:: einsteinpy.utils.exceptions
+    :members:

--- a/docs/source/api/utils/utils_index.rst
+++ b/docs/source/api/utils/utils_index.rst
@@ -7,3 +7,4 @@ The common utilities of the project are included in this module.
     :maxdepth: 2
 
     scalar_factor
+    exceptions

--- a/src/einsteinpy/coordinates/differential.py
+++ b/src/einsteinpy/coordinates/differential.py
@@ -8,6 +8,7 @@ from einsteinpy.coordinates.conversion import (
     SphericalConversion,
 )
 from einsteinpy.coordinates.utils import v0
+from einsteinpy.utils import CoordinateError
 
 _c = constant.c.value
 
@@ -106,15 +107,15 @@ class CartesianDifferential(CartesianConversion):
 
         Raises
         ------
-        TypeError
+        CoordinateError
             If ``metric`` object has been instantiated with a coordinate system, \
             other than Cartesian Coordinates.
 
         """
         g = args[0]
         if self.system != g.coords.system:
-            raise TypeError(
-                "Metric object has been instantiated with a coordinate system,"
+            raise CoordinateError(
+                f"Metric object has been instantiated with a coordinate system, ( {g.coords.system} )"
                 " other than Cartesian Coordinates."
             )
 
@@ -318,15 +319,15 @@ class SphericalDifferential(SphericalConversion):
 
         Raises
         ------
-        TypeError
+        CoordinateError
             If ``metric`` object has been instantiated with a coordinate system, \
-            other than Cartesian Coordinates.
+            other than Sperical Polar Coordinates.
 
         """
         g = args[0]
         if self.system != g.coords.system:
-            raise TypeError(
-                "Metric object has been instantiated with a coordinate system,"
+            raise CoordinateError(
+                f"Metric object has been instantiated with a coordinate system, ( {g.coords.system} )"
                 " other than Spherical Polar Coordinates."
             )
 
@@ -530,15 +531,15 @@ class BoyerLindquistDifferential(BoyerLindquistConversion):
 
         Raises
         ------
-        TypeError
+        CoordinateError
             If ``metric`` object has been instantiated with a coordinate system, \
-            other than Cartesian Coordinates.
+            other than Boyer-Lindquist Coordinates.
 
         """
         g = args[0]
         if self.system != g.coords.system:
-            raise TypeError(
-                "Metric object has been instantiated with a coordinate system,"
+            raise CoordinateError(
+                "Metric object has been instantiated with a coordinate system, ( {g.coords.system} )"
                 " other than Boyer-Lindquist Coordinates."
             )
 

--- a/src/einsteinpy/metric/base_metric.py
+++ b/src/einsteinpy/metric/base_metric.py
@@ -25,6 +25,7 @@ from astropy import units as u
 
 from einsteinpy import constant
 from einsteinpy.units import primitive
+from einsteinpy.utils import CoordinateError
 
 _c = constant.c.value
 _G = constant.G.value
@@ -283,7 +284,7 @@ class BaseMetric:
 
         Raises
         ------
-        NotImplementedError
+        CoordinateError
             If ``einsteinpy.metric.*`` does not have the metric in the \
             coordinate system, the metric object has been instantiated with
 
@@ -322,7 +323,7 @@ class BaseMetric:
                     "outer_ergosphere": _out_ergo,
                 }
 
-            raise NotImplementedError(
+            raise CoordinateError(
                 "Singularities for Kerr solutions are only available in"
                 "Boyer-Lindquist Coordinates."
             )
@@ -335,7 +336,7 @@ class BaseMetric:
                 "outer_ergosphere": r_s,
             }
 
-        raise NotImplementedError(
+        raise CoordinateError(
             "Singularities for Schwarzschild Metric are only available in"
             "Spherical Polar Coordinates."
         )

--- a/src/einsteinpy/metric/kerr.py
+++ b/src/einsteinpy/metric/kerr.py
@@ -3,6 +3,7 @@ from astropy import units as u
 
 from einsteinpy import constant
 from einsteinpy.metric import BaseMetric
+from einsteinpy.utils import CoordinateError
 
 _c = constant.c.value
 
@@ -93,15 +94,15 @@ class Kerr(BaseMetric):
 
         Raises
         ------
-        NotImplementedError
-            In case of the metric is not available in \
+        CoordinateError
+            Raised, if the metric is not available in \
             the supplied Coordinate System
 
         """
         if self.coords.system == "BoyerLindquist":
             return self._g_cov_bl(x_vec)
 
-        raise NotImplementedError(
+        raise CoordinateError(
             "Kerr Metric is available only in Boyer-Lindquist Coordinates."
         )
 
@@ -228,15 +229,15 @@ class Kerr(BaseMetric):
 
         Raises
         ------
-        NotImplementedError
-            In case of the Christoffel Symbols are not \
+        CoordinateError
+            Raised, if the Christoffel symbols are not \
             available in the supplied Coordinate System
 
         """
         if self.coords.system == "BoyerLindquist":
             return self._ch_sym_bl(x_vec)
 
-        raise NotImplementedError(
+        raise CoordinateError(
             "Christoffel Symbols for Kerr Metric are available only in Boyer-Lindquist Coordinates."
         )
 
@@ -305,15 +306,15 @@ class Kerr(BaseMetric):
 
         Raises
         ------
-        NotImplementedError
-            In case of ``f_vec`` is not available in \
+        CoordinateError
+            Raised, if ``f_vec`` is not available in \
             the supplied Coordinate System
 
         """
         if self.coords.system == "BoyerLindquist":
             return self._f_vec_bl(lambda_, vec)
 
-        raise NotImplementedError(
+        raise CoordinateError(
             "'f_vec' for Kerr Metric is available only in Boyer-Lindquist Coordinates."
         )
 

--- a/src/einsteinpy/metric/kerrnewman.py
+++ b/src/einsteinpy/metric/kerrnewman.py
@@ -3,6 +3,7 @@ from astropy import units as u
 
 from einsteinpy import constant
 from einsteinpy.metric import BaseMetric
+from einsteinpy.utils import CoordinateError
 
 _c = constant.c.value
 _G = constant.G.value
@@ -102,15 +103,15 @@ class KerrNewman(BaseMetric):
 
         Raises
         ------
-        NotImplementedError
-            In case of the metric is not available in \
+        CoordinateError
+            Raised, if the metric is not available in \
             the supplied Coordinate System
 
         """
         if self.coords.system == "BoyerLindquist":
             return self._g_cov_bl(x_vec)
 
-        raise NotImplementedError(
+        raise CoordinateError(
             "Kerr-Newman Metric is available only in Boyer-Lindquist Coordinates."
         )
 
@@ -256,15 +257,15 @@ class KerrNewman(BaseMetric):
 
         Raises
         ------
-        NotImplementedError
-            In case of the Christoffel Symbols are not \
+        CoordinateError
+            Raised, if the Christoffel Symbols are not \
             available in the supplied Coordinate System
 
         """
         if self.coords.system == "BoyerLindquist":
             return self._ch_sym_bl(x_vec)
 
-        raise NotImplementedError(
+        raise CoordinateError(
             "Christoffel Symbols for Kerr-Newman Metric are available only in Boyer-Lindquist Coordinates."
         )
 
@@ -333,15 +334,15 @@ class KerrNewman(BaseMetric):
 
         Raises
         ------
-        NotImplementedError
-            In case of ``f_vec`` is not available in \
+        CoordinateError
+            Raised, if ``f_vec`` is not available in \
             the supplied Coordinate System
 
         """
         if self.coords.system == "BoyerLindquist":
             return self._f_vec_bl(lambda_, vec)
 
-        raise NotImplementedError(
+        raise CoordinateError(
             "'f_vec' for Kerr-Newman Metric is available only in Boyer-Lindquist Coordinates."
         )
 

--- a/src/einsteinpy/metric/schwarzschild.py
+++ b/src/einsteinpy/metric/schwarzschild.py
@@ -3,6 +3,7 @@ from astropy import units as u
 
 from einsteinpy import constant
 from einsteinpy.metric import BaseMetric
+from einsteinpy.utils import CoordinateError
 
 _c = constant.c.value
 
@@ -55,7 +56,7 @@ class Schwarzschild(BaseMetric):
         if self.coords.system == "Spherical":
             return self._g_cov_s(x_vec)
 
-        raise NotImplementedError(
+        raise CoordinateError(
             "Schwarzschild Metric is available only in Spherical Polar Coordinates."
         )
 
@@ -106,15 +107,15 @@ class Schwarzschild(BaseMetric):
 
         Raises
         ------
-        NotImplementedError
-            In case of the Christoffel Symbols are not \
+        CoordinateError
+            Raised, if the Christoffel Symbols are not \
             available in the supplied Coordinate System
 
         """
         if self.coords.system == "Spherical":
             return self._ch_sym_s(x_vec)
 
-        raise NotImplementedError(
+        raise CoordinateError(
             "Christoffel Symbols for Schwarzschild Metric are available only in Spherical Polar Coordinates."
         )
 
@@ -173,15 +174,15 @@ class Schwarzschild(BaseMetric):
 
         Raises
         ------
-        NotImplementedError
-            In case of ``f_vec`` is not available in \
+        CoordinateError
+            Raised, if ``f_vec`` is not available in \
             the supplied Coordinate System
 
         """
         if self.coords.system == "Spherical":
             return self._f_vec_s(lambda_, vec)
 
-        raise NotImplementedError(
+        raise CoordinateError(
             "'f_vec' for Schwarzschild Metric is available only in Spherical Polar Coordinates."
         )
 

--- a/src/einsteinpy/utils/__init__.py
+++ b/src/einsteinpy/utils/__init__.py
@@ -1,1 +1,4 @@
+from .exceptions import BaseError, CoordinateError
 from .scalar_factor import scalar_factor, scalar_factor_derivative
+
+__all__ = ["BaseError", "CoordinateError"]

--- a/src/einsteinpy/utils/exceptions.py
+++ b/src/einsteinpy/utils/exceptions.py
@@ -1,0 +1,58 @@
+"""Docstring for exceptions.py module
+
+This module defines the ``BaseError`` class which is the base class for all \
+custom Errors in EinsteinPy, and the ``CoordinateError`` class, which is a child class \
+used for raising exceptions when the geometry does not support \
+the supplied coordinate system.
+
+"""
+
+
+class BaseError(Exception):
+    """
+    Base class for custom errors
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        | Constructor
+        | Joins ``args`` into a ``message`` string
+
+        Parameters
+        ------------
+        *args : iterable
+            Other arguments
+        **kwargs : dict
+            Keyword arguments
+
+        """
+        self.message = " ".join(str(i) for i in args)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__} : {self.message}"
+
+    def __str__(self):
+        return self.__repr__()
+
+
+class CoordinateError(BaseError):
+    """
+    Error class for invalid coordinate operations
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        | Constructor
+        | Joins ``args`` into a ``message`` string
+
+        Parameters
+        ------------
+        *args : iterable
+            Other arguments
+        **kwargs : dict
+            Keyword arguments
+
+        """
+        super().__init__(*args, **kwargs)

--- a/tests/test_coordinates/test_diff_transform.py
+++ b/tests/test_coordinates/test_diff_transform.py
@@ -14,6 +14,7 @@ from einsteinpy.coordinates import (
 )
 from einsteinpy.metric import BaseMetric, Kerr, Schwarzschild
 from einsteinpy import constant
+from einsteinpy.utils import CoordinateError
 
 _c = constant.c.value
 
@@ -223,7 +224,7 @@ def test_velocity2(spherical_differential, bl_differential):
     assert_allclose(bd.velocity(metric=mk)[1:], [bd.v_r.value, bd.v_th.value, bd.v_p.value])
 
 
-def test_v_t_raises_TypeError(cartesian_differential, spherical_differential, bl_differential):
+def test_v_t_raises_CoordinateError(cartesian_differential, spherical_differential, bl_differential):
     M = 1e24 * u.kg
     a = 0. * u.one
     ms = Schwarzschild(coords=spherical_differential, M=M)
@@ -243,16 +244,16 @@ def test_v_t_raises_TypeError(cartesian_differential, spherical_differential, bl
     def sd_k(sd, mk):
         return sd.velocity(metric=mk)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(CoordinateError):
         cd_s(cd, ms)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(CoordinateError):
         bd_s(bd, ms)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(CoordinateError):
         cd_k(cd, mk)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(CoordinateError):
         sd_k(sd, mk)
 
 
@@ -268,17 +269,17 @@ def test_v_t_getter_setter0(cartesian_differential, spherical_differential, bl_d
     def sd_vt(spherical_differential, mk):
         spherical_differential.v_t = (mk,)
 
-    # This should not raise TypeError
+    # This should not raise CoordinateError
     try:
         spherical_differential.v_t = (ms,)
-    except TypeError:
+    except CoordinateError:
         pytest.fail("Unexpected TypeError!")
 
-    # These 2 should raise TypeError
-    with pytest.raises(TypeError):
+    # These 2 should raise CoordinateError
+    with pytest.raises(CoordinateError):
         cd_vt(cartesian_differential, ms)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(CoordinateError):
         sd_vt(spherical_differential, mk)
 
 
@@ -291,14 +292,14 @@ def test_v_t_getter_setter1(cartesian_differential, spherical_differential, bl_d
     def bd_vt(bl_differential, ms):
         bl_differential.v_t = (ms,)
 
-    # This should not raise TypeError
+    # This should not raise CoordinateError
     try:
         bl_differential.v_t = (mk,)
-    except TypeError:
+    except CoordinateError:
         pytest.fail("Unexpected TypeError!")
 
     # This should raise TypeError
-    with pytest.raises(TypeError):
+    with pytest.raises(CoordinateError):
         bd_vt(bl_differential, ms)
 
 

--- a/tests/test_metric/test_base_metric.py
+++ b/tests/test_metric/test_base_metric.py
@@ -10,6 +10,7 @@ from einsteinpy import constant
 from einsteinpy.coordinates import SphericalDifferential, BoyerLindquistDifferential
 
 from einsteinpy.metric import BaseMetric, Kerr, KerrNewman, Schwarzschild
+from einsteinpy.utils.exceptions import CoordinateError
 
 _c = constant.c.value
 
@@ -119,7 +120,7 @@ def dummy_input(sph, bl):
 
 def test_coordinate_mismatch0(dummy_input):
     """
-    Tests, if NotImplementedError is raised, in case of coordinate system mismatch, \
+    Tests, if CoordinateError is raised, in case of coordinate system mismatch, \
     between metric coordinates and supplied coordinates
 
     """
@@ -137,22 +138,22 @@ def test_coordinate_mismatch0(dummy_input):
     def test_ms_con(ms):
         ms_cov = ms.metric_contravariant(x_vec_sph)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_ms_cov(ms)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_mk_cov(mk)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_mkn_cov(mkn)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_ms_con(ms)
 
 
 def test_coordinate_mismatch1(dummy_input):
     """
-    Tests, if NotImplementedError is raised, in case of coordinate system mismatch, \
+    Tests, if CoordinateError is raised, in case of coordinate system mismatch, \
     between metric coordinates and supplied coordinates
 
     """
@@ -170,22 +171,22 @@ def test_coordinate_mismatch1(dummy_input):
     def test_ms_fvec(ms):
         ms_fvec = ms.f_vec(0., x_vec_sph)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_ms_chl(ms)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_mk_chl(mk)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_mkn_chl(mkn)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_ms_fvec(ms)
 
 
 def test_coordinate_mismatch2(dummy_input):
     """
-    Tests, if NotImplementedError is raised, in case of coordinate system mismatch, \
+    Tests, if CoordinateError is raised, in case of coordinate system mismatch, \
     between metric coordinates and supplied coordinates
 
     """
@@ -203,16 +204,16 @@ def test_coordinate_mismatch2(dummy_input):
     def test_mkn_fvec(mkn):
         ms_fvec = mkn.f_vec(0., x_vec_bl)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_mk_con(mk)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_mkn_con(mkn)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_mk_fvec(mk)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         test_mkn_fvec(mkn)
 
 
@@ -380,9 +381,9 @@ def test_singularities_for_uncharged_nonrotating_case(sph, bl):
     assert_allclose(mksinglist[2], scr, rtol=1e-4, atol=0.0)
 
 
-def test_singularities_raises_NotImplementedError(sph, bl):
+def test_singularities_raises_CoordinateError(sph, bl):
     """
-    Tests, if ``singularities()`` raises a NotImplementedError, \
+    Tests, if ``singularities()`` raises a CoordinateError, \
     when there is a coordinate mismatch between supplied coordinate \
     object and the coordinate object, metric was instantiated with
 
@@ -406,13 +407,13 @@ def test_singularities_raises_NotImplementedError(sph, bl):
     def mknsing(mkn):
         mknsing = mkn.singularities()
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         mssing(ms)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         mksing(mk)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(CoordinateError):
         mknsing(mkn)
 
 

--- a/tests/test_utils/test_exceptions.py
+++ b/tests/test_utils/test_exceptions.py
@@ -1,0 +1,43 @@
+import pytest
+
+from einsteinpy.utils import CoordinateError
+
+
+def test_CoordinateError_class():
+    """
+    Tests, if the errors raised with the CoordinateError class \
+    ``einsteinpy.coordinates.utils.CoordinateError`` are \
+    appropriate
+
+    """
+    err_string = " ".join(
+        str(i)
+        for i in [
+            "Error",
+            404,
+            chr(0xA),
+            "\bPage Found =",
+            False,
+            "\b, Please contact :",
+            11.223344,
+            None,
+            0x1F76,
+            12e-4,
+        ]
+    )
+    err = CoordinateError(
+        "Error",
+        404,
+        chr(0xA),
+        "\bPage Found =",
+        False,
+        "\b, Please contact :",
+        11.223344,
+        None,
+        0x1F76,
+        12e-4,
+    )
+
+    assert hasattr(err, "message")
+    assert str(err) == repr(err)
+    assert err_string == err.message


### PR DESCRIPTION
<!-- Please fill below the issue number which this code fixes -->
Fixes #526 

<!-- Please tag any reviewer here -->
@shreyasbapat @JeS24 

- I have implemented a base `Error` class and child `CoordinateError` class ( could be useful for future Error types ) in `einsteinpy.coordinates.utils`.
- replaced the `TypeError` and `NotImplementedError` raises where necessary.
- `einsteinpy.symbolic.BaseRelativityTensor` raises `TypeError` but isnt related to issue at hand ( i.e. coordinate operations). Hence not changed.

Please suggest any changes/corrections needed. Thanks
