### PR TITLE
Don't raise when a > 1

### DIFF
--- a/src/einsteinpy/metric/base_metric.py
+++ b/src/einsteinpy/metric/base_metric.py
@@ -252,15 +252,15 @@ class BaseMetric:
         float
             Rotational Length Parameter
 
-        Raises
+        Warning
         ------
-        ValueError
-            If a is not between 0 and 1
+        Warn
+            If a is not between 0 and 1 - lots of things will break, but some will work!
 
         """
         M, a = primitive(M, a)
         if a < 0 or a > 1:
-            raise ValueError("Spin Parameter, a, should be between 0 and 1.")
+            warnings.warn("Spin Parameter, a, should be between 0 and 1.")
         half_rs = _G * M / _c ** 2
 
         return a * half_rs


### PR DESCRIPTION
a > 1 actually works ok in a lot of the code, print a warning instead of simply Raise and crash.

<!-- Please fill below the issue number which this code fixes -->
Fixes #<Put_Issue_Number_Here>

<!-- Please tag any reviewer here -->

