### PR TITLE
Fixes #616 - Drop Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   quality:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.8
     parallelism: 4
     working_directory: ~/repo
 
@@ -29,9 +29,9 @@ jobs:
           command: |
             . venv/bin/activate
             mypy --ignore-missing-imports --check-untyped-defs --no-strict-optional src/
-  test_py37: &test-template  # See https://discuss.circleci.com/t/run-tests-on-multiple-versions-of-python/15462/2
+  test_py38: &test-template
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.8
 
     working_directory: ~/repo
 
@@ -52,14 +52,18 @@ jobs:
           command: |
             . venv/bin/activate
             MPLBACKEND=Agg pytest -n 8 -vv  # Test against installed code (Can use --doctest-modules)
-  test_py38:
+  test_py39:
     <<: *test-template
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.9
+  test_py310:
+    <<: *test-template
+    docker:
+      - image:  cimg/python:3.10
 
   coverage:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.8
 
     working_directory: ~/repo
 
@@ -86,7 +90,7 @@ jobs:
             codecov
   docs:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.8
 
     working_directory: ~/repo
 
@@ -115,10 +119,13 @@ workflows:
   build_and_test:
     jobs:
       - quality
-      - test_py37:
+      - test_py38:
           requires:
             - quality
-      - test_py38:
+      - test_py39:
+          requires:
+            - quality
+      - test_py310:
           requires:
             - quality
       - coverage:
@@ -126,5 +133,6 @@ workflows:
             - quality
       - docs:
           requires:
-            - test_py37
             - test_py38
+            - test_py39
+            - test_py310

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,8 +6,8 @@ project = "EinsteinPy"
 year = datetime.now().year
 copyright = "%d EinsteinPy Development Team" % year
 
-version = "0.4"
-release = "0.4.dev0"
+version = "0.5"
+release = "0.5.dev0"
 highlight_language = "python"
 pygments_style = "sphinx"
 autoclass_content = "both"

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
         sympy>=1.1
         numba>=0.46,!=0.49.0 ; implementation_name=='cpython'
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@ envlist =
     clean,
     check,
     docs,
-    py37,
     py38,
+    py39,
+    py310,
     pypy,
     pypy3
 
@@ -13,8 +14,9 @@ envlist =
 basepython =
     pypy: {env:PYTHON:pypy}
     pypy3: {env:PYTHON:pypy3}
-    py37: {env:PYTHON:python3.7}
-    {py38,docs}: {env:PYTHON:python3.7}
+    py38: {env:PYTHON:python3.8}
+    py39: {env:PYTHON:python3.9}
+    {py310,docs}: {env:PYTHON:python3.10}
     {clean,check,reformat}: {env:PYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests


### PR DESCRIPTION
<!-- Please fill below the issue number which this code fixes -->
Fixes #616.

Summary;
- Python 3.7 dropped. 3.8 now baseline. 3.9, 3.10 added.
- Unrelated: Sphinx `conf.py` version bump to `0.5.0`.

<!-- Please tag any reviewer here -->

