### PR TITLE
Fix r_s in Alcubierre warp metric

### DIFF
--- a/src/einsteinpy/symbolic/predefined/alcubierre_warp.py
+++ b/src/einsteinpy/symbolic/predefined/alcubierre_warp.py
@@ -40,7 +40,7 @@ def AlcubierreWarp(
     """
     coords = symbols("t x y z")
     t, x, y, z = coords
-    r_s = sqrt((x - x_s) ** 2 + y ** 2 + z ** 2)
+    r_s = sqrt((x - x_s) ** 2 + y**2 + z**2)
     f = (tanh(sigma * (r_s + R)) - tanh(sigma * (r_s - R))) / (2 * tanh(sigma * R))
 
     v2 = v**2

--- a/src/einsteinpy/symbolic/predefined/alcubierre_warp.py
+++ b/src/einsteinpy/symbolic/predefined/alcubierre_warp.py
@@ -40,7 +40,7 @@ def AlcubierreWarp(
     """
     coords = symbols("t x y z")
     t, x, y, z = coords
-    r_s = sqrt((x - x_s) ** 2 + y + z)
+    r_s = sqrt((x - x_s) ** 2 + y ** 2 + z ** 2)
     f = (tanh(sigma * (r_s + R)) - tanh(sigma * (r_s - R))) / (2 * tanh(sigma * R))
 
     v2 = v**2


### PR DESCRIPTION
Hello, I think the Alcubierre warp metric isn't quite right. For reference, the formula can be found in the [original paper](https://arxiv.org/pdf/gr-qc/0009013) just above formula 6 but it's supposed to be the distance to x_s so I think the fix is somewhat self-explanatory.

Thanks for your work on EinsteinPy!

